### PR TITLE
ESBJAVA-4927: Fixing the issue of a SOCKS proxy being identified as an HTTP proxy in file manipulation through SFTP

### DIFF
--- a/core/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
+++ b/core/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
@@ -715,10 +715,19 @@ public class DefaultFileSystemManager implements FileSystemManager
 					}
 					String proxyUser = queryParam.get(SftpConstants.PROXY_USERNAME);
 					String proxyPassword = queryParam.get(SftpConstants.PROXY_PASSWORD);
+                    String proxyType = queryParam.get(SftpConstants.PROXY_TYPE);
 
-					((SftpFileSystemConfigBuilder) (provider.getConfigBuilder())).setProxyType(fileSystemOptions,
-					                                                                           SftpFileSystemConfigBuilder.PROXY_HTTP);
-					((SftpFileSystemConfigBuilder) (provider.getConfigBuilder())).setProxyHost(fileSystemOptions,
+                    if (SftpConstants.SOCKS.equals(proxyType)) {
+                        ((SftpFileSystemConfigBuilder) (provider.getConfigBuilder()))
+                                .setProxyType(fileSystemOptions, SftpFileSystemConfigBuilder.PROXY_SOCKS5);
+                    } else {
+                        if (proxyType != null && !proxyType.isEmpty() && !SftpConstants.HTTP.equals(proxyType)) {
+                            log.warn(proxyType + " is not a supported proxy type. Trying with HTTP");
+                        }
+                        ((SftpFileSystemConfigBuilder) (provider.getConfigBuilder()))
+                                .setProxyType(fileSystemOptions, SftpFileSystemConfigBuilder.PROXY_HTTP);
+                    }
+                    ((SftpFileSystemConfigBuilder) (provider.getConfigBuilder())).setProxyHost(fileSystemOptions,
 					                                                                           proxyHost);
 					((SftpFileSystemConfigBuilder) (provider.getConfigBuilder())).setProxyPort(fileSystemOptions,
 					                                                                           proxyPort);

--- a/core/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpConstants.java
+++ b/core/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpConstants.java
@@ -19,10 +19,13 @@ package org.apache.commons.vfs2.provider.sftp;
 public interface SftpConstants {
 
     public String SFTP_PATH_FROM_ROOT= "sftpPathFromRoot";
+    public String PROXY_TYPE = "proxyType";
     public String PROXY_SERVER = "proxyServer";
     public String PROXY_PORT = "proxyPort";
     public String PROXY_USERNAME = "proxyUsername";
     public String PROXY_PASSWORD = "proxyPassword";
     public String TIMEOUT = "timeout";
     public String RETRY_COUNT = "retryCount";
+    public String SOCKS = "socks";
+    public String HTTP = "http";
 }


### PR DESCRIPTION
https://wso2.org/jira/browse/ESBJAVA-4927