### PR TITLE
Obfuscating FTP passwords in FileNotFoundException stacktrace 

### DIFF
--- a/core/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpFileObject.java
+++ b/core/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpFileObject.java
@@ -616,7 +616,7 @@ public class FtpFileObject extends AbstractFileObject
             // VFS-210
             if (instr == null)
             {
-                throw new FileNotFoundException(getName().toString());
+                throw new FileNotFoundException(getName().getFriendlyURI());
             }
             return new FtpInputStream(client, instr);
         }

--- a/core/src/test/java/org/apache/commons/vfs2/provider/test/GenericFileNameTestCase.java
+++ b/core/src/test/java/org/apache/commons/vfs2/provider/test/GenericFileNameTestCase.java
@@ -47,6 +47,7 @@ public class GenericFileNameTestCase
         assertEquals("/file", name.getPath());
         assertEquals("ftp://hostname/", name.getRootURI());
         assertEquals("ftp://hostname/file", name.getURI());
+        assertEquals("ftp://hostname/file", name.getFriendlyURI());
 
         // Name with port
         name = (GenericFileName) urlParser.parseUri(null, null, "ftp://hostname:9090/file");
@@ -58,6 +59,7 @@ public class GenericFileNameTestCase
         assertEquals("/file", name.getPath());
         assertEquals("ftp://hostname:9090/", name.getRootURI());
         assertEquals("ftp://hostname:9090/file", name.getURI());
+        assertEquals("ftp://hostname:9090/file", name.getFriendlyURI());
 
         // Name with no path
         name = (GenericFileName) urlParser.parseUri(null, null, "ftp://hostname");
@@ -69,6 +71,7 @@ public class GenericFileNameTestCase
         assertEquals("/", name.getPath());
         assertEquals("ftp://hostname/", name.getRootURI());
         assertEquals("ftp://hostname/", name.getURI());
+        assertEquals("ftp://hostname/", name.getFriendlyURI());
 
         // Name with username
         name = (GenericFileName) urlParser.parseUri(null, null, "ftp://user@hostname/file");
@@ -80,6 +83,7 @@ public class GenericFileNameTestCase
         assertEquals("/file", name.getPath());
         assertEquals("ftp://user@hostname/", name.getRootURI());
         assertEquals("ftp://user@hostname/file", name.getURI());
+        assertEquals("ftp://user@hostname/file", name.getFriendlyURI());
 
         // Name with username and password
         name = (GenericFileName) urlParser.parseUri(null, null, "ftp://user:password@hostname/file");
@@ -91,6 +95,7 @@ public class GenericFileNameTestCase
         assertEquals("/file", name.getPath());
         assertEquals("ftp://user:password@hostname/", name.getRootURI());
         assertEquals("ftp://user:password@hostname/file", name.getURI());
+        assertEquals("ftp://user:***@hostname/file", name.getFriendlyURI());
 
         // Encoded username and password
         name = (GenericFileName) urlParser.parseUri(null, null, "ftp://%75ser%3A:%40@hostname");
@@ -102,6 +107,7 @@ public class GenericFileNameTestCase
         assertEquals("/", name.getPath());
         assertEquals("ftp://user%3a:%40@hostname/", name.getRootURI());
         assertEquals("ftp://user%3a:%40@hostname/", name.getURI());
+        assertEquals("ftp://user%3a:***@hostname/", name.getFriendlyURI());
     }
 
     /**


### PR DESCRIPTION
This will mask the FTP passwords which was visible in the stack trace of FileNotFoundException. This fix will provide the above solution for FTPFileObjects.

Jira - https://wso2.org/jira/browse/ESBJAVA-5226