### PR TITLE
Merge fix VFS-189

### DIFF
--- a/core/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
+++ b/core/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
@@ -805,8 +805,11 @@ public class DefaultFileSystemManager implements FileSystemManager
     public FileName resolveName(final FileName base, final String name,
             final NameScope scope) throws FileSystemException
     {
+        if (base == null) {
+            throw new FileSystemException("Invalid base filename.");
+        }
         final FileName realBase;
-        if (base != null && VFS.isUriStyle() && base.getType() == FileType.FILE)
+        if (VFS.isUriStyle() && base.getType() == FileType.FILE)
         {
             realBase = base.getParent();
         }

--- a/core/src/test/java/org/apache/commons/vfs2/impl/test/DefaultFileSystemManagerTest.java
+++ b/core/src/test/java/org/apache/commons/vfs2/impl/test/DefaultFileSystemManagerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.vfs2.impl.test;
+
+import java.io.File;
+
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.VFS;
+import org.junit.Test;
+
+public class DefaultFileSystemManagerTest {
+    @Test(expected = NullPointerException.class)
+    public void testResolveFileRelativeThrows() throws FileSystemException {
+        VFS.getManager().resolveFile((File) null, "relativePath");
+    }
+
+    /**
+     * Even if the file name is absolute, the base file must be given. This is an inconsistency in the API, but it is
+     * documented as such.
+     *
+     * @see "VFS-519"
+     */
+    @Test(expected = NullPointerException.class)
+    public void testResolveFileAbsoluteThrows() throws FileSystemException {
+        final String absolute = new File("/").getAbsoluteFile().toURI().toString();
+        VFS.getManager().resolveFile((File) null, absolute);
+    }
+
+    @Test(expected = FileSystemException.class)
+    public void testResolveFileObjectRelativeThrows() throws FileSystemException {
+        VFS.getManager().resolveFile((FileObject) null, "relativePath");
+    }
+
+    @Test
+    public void testResolveFileObjectNullAbsolute() throws FileSystemException {
+        final String absolute = new File("/").getAbsoluteFile().toURI().toString();
+        VFS.getManager().resolveFile((FileObject) null, absolute);
+    }
+
+    /**
+     * If the base name is {@code null}, the file system manager should fail throwing a FileSystemException.
+     *
+     * @see VFS-189
+     */
+    @Test(expected = FileSystemException.class)
+    public void testResolveFileNameNull() throws FileSystemException {
+        VFS.getManager().resolveName((FileName) null, "../");
+    }
+}


### PR DESCRIPTION
## Purpose
Fix the null pointer exception in the resolveName method if the method parameter  'base' is null.
https://issues.apache.org/jira/browse/VFS-189

## Goals
> merge the fix for the null pointer issue from VFS-189

## Approach
> 

## User stories
> 

## Release note
> 

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
 

## Security checks

## Samples
> 

## Related PRs
>

## Migrations (if applicable)
> 

## Test environment
> 
 
## Learning
> 