### PR TITLE
Fix ftp url parsing issue

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/HostFileNameParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/HostFileNameParser.java
@@ -31,6 +31,11 @@ import org.apache.commons.vfs2.util.CryptorFactory;
  */
 public class HostFileNameParser extends AbstractFileNameParser {
     private final int defaultPort;
+    private static final HostFileNameParser INSTANCE = new HostFileNameParser(21);
+
+    public static FileNameParser getInstance() {
+        return INSTANCE;
+    }
 
     public HostFileNameParser(final int defaultPort) {
         this.defaultPort = defaultPort;

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftps/FtpsFileProvider.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftps/FtpsFileProvider.java
@@ -22,6 +22,7 @@ import org.apache.commons.vfs2.FileSystemConfigBuilder;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.provider.GenericFileName;
+import org.apache.commons.vfs2.provider.HostFileNameParser;
 import org.apache.commons.vfs2.provider.ftp.FtpFileProvider;
 
 /**
@@ -35,6 +36,7 @@ import org.apache.commons.vfs2.provider.ftp.FtpFileProvider;
 public class FtpsFileProvider extends FtpFileProvider {
     public FtpsFileProvider() {
         super();
+        setFileNameParser(HostFileNameParser.getInstance());
     }
 
     /**


### PR DESCRIPTION
## Purpose
When file uri contains a query parameter the relative path has been resolved with the query parameter. It has been fixed by overriding  the parseUri method of HostFileNameParser.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
