### PR TITLE
Add property to avoid checking permissions.

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
@@ -101,6 +101,12 @@ public class DefaultFileSystemManager implements FileSystemManager {
     private FileProvider defaultProvider;
 
     /**
+     * This constant holds the avoid permission check parameter for sftp servers.
+     * e.g:  sftp://admin":password@"localhost/in2\?transport.vfs.AvoidPermissionCheck=true
+     */
+    private final static String PERMISSION_CHECK = "transport.vfs.AvoidPermissionCheck";
+
+    /**
      * The file replicator to use.
      */
     private FileReplicator fileReplicator;
@@ -717,6 +723,13 @@ public class DefaultFileSystemManager implements FileSystemManager {
                 if (fileSystemOptions == null) {
                     fileSystemOptions = new FileSystemOptions();
                 }
+
+                String permissionCheck = queryParam.get(PERMISSION_CHECK);
+                SftpFileSystemConfigBuilder builder = SftpFileSystemConfigBuilder.getInstance();
+                if (builder.getAvoidPermissionCheck(fileSystemOptions) == null) {
+                    builder.setAvoidPermissionCheck(fileSystemOptions, permissionCheck);
+                }
+
                 if ("true".equals(queryParam.get(SftpConstants.SFTP_PATH_FROM_ROOT))) {
                     ((SftpFileSystemConfigBuilder) (((SftpFileProvider) provider).getConfigBuilder()))
                             .setUserDirIsRoot(fileSystemOptions, false);

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
@@ -16,13 +16,10 @@
  */
 package org.apache.commons.vfs2.provider.sftp;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.Vector;
-
+import com.jcraft.jsch.ChannelSftp;
+import com.jcraft.jsch.ChannelSftp.LsEntry;
+import com.jcraft.jsch.SftpATTRS;
+import com.jcraft.jsch.SftpException;
 import org.apache.commons.vfs2.FileNotFoundException;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
@@ -39,10 +36,12 @@ import org.apache.commons.vfs2.util.MonitorOutputStream;
 import org.apache.commons.vfs2.util.PosixPermissions;
 import org.apache.commons.vfs2.util.RandomAccessMode;
 
-import com.jcraft.jsch.ChannelSftp;
-import com.jcraft.jsch.ChannelSftp.LsEntry;
-import com.jcraft.jsch.SftpATTRS;
-import com.jcraft.jsch.SftpException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Vector;
 
 /**
  * An SFTP file.
@@ -52,7 +51,6 @@ public class SftpFileObject extends AbstractFileObject<SftpFileSystem> {
 
     private SftpATTRS attrs;
     private final String relPath;
-
     private boolean inRefresh;
 
     protected SftpFileObject(final AbstractFileName name, final SftpFileSystem fileSystem) throws FileSystemException {
@@ -262,7 +260,21 @@ public class SftpFileObject extends AbstractFileObject<SftpFileSystem> {
 
     @Override
     protected boolean doIsReadable() throws Exception {
-        return getPermissions(true).isReadable();
+        if (isPermissionCheckRequired()) {
+            return getPermissions(true).isReadable();
+        } else {
+            return true;
+        }
+    }
+
+    private boolean isPermissionCheckRequired() throws Exception {
+        String permissionCheck = SftpFileSystemConfigBuilder.getInstance().getAvoidPermissionCheck
+                (getAbstractFileSystem().getFileSystemOptions());
+        if (permissionCheck != null && permissionCheck.equalsIgnoreCase("true")) {
+            return false;
+        } else {
+            return true;
+        }
     }
 
     @Override
@@ -281,7 +293,11 @@ public class SftpFileObject extends AbstractFileObject<SftpFileSystem> {
 
     @Override
     protected boolean doIsWriteable() throws Exception {
-        return getPermissions(true).isWritable();
+        if (isPermissionCheckRequired()) {
+            return getPermissions(true).isWritable();
+        } else {
+            return true;
+        }
     }
 
     @Override
@@ -300,7 +316,11 @@ public class SftpFileObject extends AbstractFileObject<SftpFileSystem> {
 
     @Override
     protected boolean doIsExecutable() throws Exception {
-        return getPermissions(true).isExecutable();
+        if (isPermissionCheckRequired()) {
+            return getPermissions(true).isExecutable();
+        } else {
+            return true;
+        }
     }
 
     @Override

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileSystemConfigBuilder.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileSystemConfigBuilder.java
@@ -121,6 +121,8 @@ public final class SftpFileSystemConfigBuilder extends FileSystemConfigBuilder {
     private static final String USER_DIR_IS_ROOT = _PREFIX + ".USER_DIR_IS_ROOT";
     private static final String ENCODING = _PREFIX + ".ENCODING";
     private static final String PASS_PHRASE = "identitypassphrase";
+    private static final String PERMISSION_CHECK = "avoidpermissioncheck";
+
 
     private SftpFileSystemConfigBuilder() {
         super("sftp.");
@@ -158,6 +160,26 @@ public final class SftpFileSystemConfigBuilder extends FileSystemConfigBuilder {
      */
     public void setIdentityPassPhrase(FileSystemOptions opts, String identityPassPhrase) throws FileSystemException {
         setParam(opts, PASS_PHRASE, identityPassPhrase);
+    }
+
+    /**
+     * Get the avoid permission check parameter for sftp servers.
+     *
+     * @param opts The FileSystem options.
+     * @return the permissionCheck.
+     */
+    public String getAvoidPermissionCheck(FileSystemOptions opts) {
+        return (String) this.getParam(opts, PERMISSION_CHECK);
+    }
+
+    /**
+     * Set the avoid permission check parameter for sftp servers.
+     *
+     * @param opts            The FileSystem options.
+     * @param permissionCheck Avoid permission check parameter.
+     */
+    public void setAvoidPermissionCheck(FileSystemOptions opts, String permissionCheck) {
+        setParam(opts, PERMISSION_CHECK, permissionCheck);
     }
 
     @Override


### PR DESCRIPTION
## Purpose
Add property to avoid checking permissions with id -G command
while reading/writing file from a sftp server.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Provide high-level details about the samples related to this feature
