### PR TITLE
Resolve Access is denied when using smb

### DIFF
--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb/SmbFileObject.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb/SmbFileObject.java
@@ -80,23 +80,22 @@ public class SmbFileObject extends AbstractFileObject<SmbFileSystem> {
             authData = UserAuthenticatorUtils.authenticate(getFileSystem().getFileSystemOptions(),
                     SmbFileProvider.AUTHENTICATOR_TYPES);
 
-            NtlmPasswordAuthentication auth = null;
-            if (authData != null) {
-                auth = new NtlmPasswordAuthentication(
-                        UserAuthenticatorUtils.toString(UserAuthenticatorUtils.getData(authData,
-                                UserAuthenticationData.DOMAIN, UserAuthenticatorUtils.toChar(smbFileName.getDomain()))),
-                        UserAuthenticatorUtils
-                                .toString(UserAuthenticatorUtils.getData(authData, UserAuthenticationData.USERNAME,
-                                        UserAuthenticatorUtils.toChar(smbFileName.getUserName()))),
-                        UserAuthenticatorUtils
-                                .toString(UserAuthenticatorUtils.getData(authData, UserAuthenticationData.PASSWORD,
-                                        UserAuthenticatorUtils.toChar(smbFileName.getPassword()))));
-            }
-
-            // if auth == null SmbFile uses default credentials
-            // ("jcifs.smb.client.domain", "?"), ("jcifs.smb.client.username", "GUEST"),
-            // ("jcifs.smb.client.password", BLANK);
-            // ANONYMOUS=("","","")
+            NtlmPasswordAuthentication auth = new NtlmPasswordAuthentication(
+                    UserAuthenticatorUtils.toString(
+                            UserAuthenticatorUtils.getData(
+                                    authData,
+                                    UserAuthenticationData.DOMAIN,
+                                    UserAuthenticatorUtils.toChar(smbFileName.getDomain()))),
+                    UserAuthenticatorUtils.toString(
+                            UserAuthenticatorUtils.getData(
+                                    authData,
+                                    UserAuthenticationData.USERNAME,
+                                    UserAuthenticatorUtils.toChar(smbFileName.getUserName()))),
+                    UserAuthenticatorUtils.toString(
+                            UserAuthenticatorUtils.getData(
+                                    authData,
+                                    UserAuthenticationData.PASSWORD,
+                                    UserAuthenticatorUtils.toChar(smbFileName.getPassword()))));
             file = new SmbFile(path, auth);
 
             if (file.isDirectory() && !file.toString().endsWith("/")) {


### PR DESCRIPTION
## Purpose
Getting the following error when connecting to smb

Caused by: jcifs.smb.SmbAuthException: Access is denied.
	at jcifs.smb.SmbTransport.checkStatus(SmbTransport.java:546)
	at jcifs.smb.SmbTransport.send(SmbTransport.java:663)
	at jcifs.smb.SmbSession.send(SmbSession.java:238)
	at jcifs.smb.SmbTree.treeConnect(SmbTree.java:176)
	at jcifs.smb.SmbFile.doConnect(SmbFile.java:911)
	at jcifs.smb.SmbFile.connect(SmbFile.java:954)
	at jcifs.smb.SmbFile.connect0(SmbFile.java:880)
	at jcifs.smb.SmbFile.exists(SmbFile.java:1415)
	at org.apache.commons.vfs2.provider.smb.SmbFileObject.doGetType(SmbFileObject.java:116)
	at org.apache.commons.vfs2.provider.AbstractFileObject.getType(AbstractFileObject.java:1285)

This PR is to solve the issue wso2/product-ei#2157

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.