### PR TITLE
Implement hashCode method in IdentityInfo

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/IdentityInfo.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/IdentityInfo.java
@@ -17,6 +17,7 @@
 package org.apache.commons.vfs2.provider.sftp;
 
 import java.io.File;
+import java.util.Arrays;
 
 /**
  * Structure for an identity.
@@ -99,5 +100,24 @@ public class IdentityInfo {
      */
     public byte[] getPassPhrase() {
         return passPhrase;
+    }
+
+    @Override
+    public int hashCode() {
+        // path of key file is considered instead of the file object because the hashes of 2 file objects
+        // are different even if the file objects are pointing to the same key file.
+        String[] identityData = {(privateKey != null ? privateKey.getAbsolutePath() : null),
+                                 (publicKey != null ? publicKey.getAbsolutePath() : null),
+                                 Arrays.toString(passPhrase)};
+        return Arrays.hashCode(identityData);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj != null) {
+            return (hashCode() == obj.hashCode());
+        } else {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
HashCode is now calculated based on file paths of the keyfiles instead of file objects because two file objects are different even if they point to the same keyfile.
This was done to avoid creating redundant sftp connections because it was not possible to identify that there already exist a sftp connection with same properties.

Fixes wso2/product-ei#3384