### PR TITLE
Add SMB v2/3 support with smbj

### DIFF
--- a/commons-vfs2-sandbox/pom.xml
+++ b/commons-vfs2-sandbox/pom.xml
@@ -50,6 +50,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>com.hierynomus.wso2</groupId>
+      <artifactId>smbj</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>commons-httpclient</groupId>
       <artifactId>commons-httpclient</artifactId>
       <optional>true</optional>

--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2ClientWrapper.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2ClientWrapper.java
@@ -123,6 +123,9 @@ public class Smb2ClientWrapper extends SMBClient {
         try {
             return diskShare.getFileInformation(relativePath);
         } catch (Exception e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Could not get information for file: " + relativePath);
+            }
             return null;
         }
     }

--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2ClientWrapper.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2ClientWrapper.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.commons.vfs2.provider.smb2;
+
+import com.hierynomus.msdtyp.AccessMask;
+import com.hierynomus.msfscc.FileAttributes;
+import com.hierynomus.msfscc.fileinformation.FileAllInformation;
+import com.hierynomus.msfscc.fileinformation.FileIdBothDirectoryInformation;
+import com.hierynomus.mssmb2.SMB2CreateDisposition;
+import com.hierynomus.mssmb2.SMB2CreateOptions;
+import com.hierynomus.mssmb2.SMB2ShareAccess;
+import com.hierynomus.mssmb2.SMBApiException;
+import com.hierynomus.smbj.SMBClient;
+import com.hierynomus.smbj.SmbConfig;
+import com.hierynomus.smbj.auth.AuthenticationContext;
+import com.hierynomus.smbj.connection.Connection;
+import com.hierynomus.smbj.session.Session;
+import com.hierynomus.smbj.share.DiskEntry;
+import com.hierynomus.smbj.share.DiskShare;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.provider.GenericFileName;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+
+/**
+ * A wrapper to the SMBClient for bundling the related client & connection instances.
+ */
+public class Smb2ClientWrapper extends SMBClient {
+
+    private static final Log LOG = LogFactory.getLog(Smb2ClientWrapper.class);
+
+    private static final SmbConfig CONFIG = SmbConfig.builder()
+            .withDfsEnabled(true)
+            .withMultiProtocolNegotiate(true)
+            .build();
+
+    protected final FileSystemOptions fileSystemOptions;
+    private final GenericFileName root;
+    private SMBClient smbClient;
+    private Connection connection;
+    private Session session;
+    private DiskShare diskShare;
+
+    protected Smb2ClientWrapper(final GenericFileName root, final FileSystemOptions fileSystemOptions)
+            throws FileSystemException {
+
+        this.root = root;
+        this.fileSystemOptions = fileSystemOptions;
+        smbClient = new SMBClient(CONFIG);
+        setupClient();
+    }
+
+    private void setupClient() throws FileSystemException {
+
+        final GenericFileName rootName = getRoot();
+
+        //the relevant data to authenticate a connection
+        final String userString = rootName.getUserName();
+        String userName = "";
+        if (userString != null && !userString.isEmpty()) {
+            if (userString.contains(";")) {
+                userName = userString.substring(userString.indexOf(";") + 1, userString.length());
+            } else {
+                userName = userString;
+            }
+        }
+
+        String password = rootName.getPassword();
+        String authDomain = (userString.contains(";") ?
+                userString.substring(0, userString.indexOf(";")) : null);
+
+        //if username == "" the client tries to authenticate "anonymously". It's also possible to submit "guest" as username
+        AuthenticationContext authContext = new AuthenticationContext(userName, password.toCharArray(), authDomain);
+
+        //a connection stack is: SMBClient > Connection > Session > DiskShare
+        try {
+            connection = smbClient.connect(rootName.getHostName());
+            session = connection.authenticate(authContext);
+            String share = ((Smb2FileName) rootName).getShareName();
+            diskShare = (DiskShare) session.connectShare(share);
+        } catch (Exception e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Error while creating connection to " + rootName.getHostName());
+            }
+            throw new FileSystemException("vfs.provider.smb2/connect.error", rootName.getHostName(), e);
+        }
+    }
+
+    public GenericFileName getRoot() {
+
+        return root;
+    }
+
+    /**
+     * Returns file information of a given file.
+     *
+     * @param relativePath of file
+     * @return FileAllInformation object
+     */
+    public FileAllInformation getFileInfo(String relativePath) {
+
+        try {
+            return diskShare.getFileInformation(relativePath);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Returns a write handle on the file.
+     *
+     * @param path path to file
+     * @return DiskEntry file
+     */
+    public DiskEntry getDiskEntryWrite(String path) {
+
+        return diskShare.open(path,
+                EnumSet.of(AccessMask.MAXIMUM_ALLOWED),
+                EnumSet.of(FileAttributes.FILE_ATTRIBUTE_NORMAL),
+                EnumSet.of(SMB2ShareAccess.FILE_SHARE_WRITE),
+                SMB2CreateDisposition.FILE_OPEN_IF,
+                EnumSet.of(SMB2CreateOptions.FILE_NO_COMPRESSION));
+    }
+
+    /**
+     * Creates a folder on a given path.
+     *
+     * @param path of folder
+     */
+    public void createFolder(String path) {
+
+        DiskEntry de = getDiskEntryFolderWrite(path);
+        de.close();
+    }
+
+    /**
+     * Returns a handle for a folder.
+     *
+     * @param path folder path
+     * @return DiskEntry
+     */
+    public DiskEntry getDiskEntryFolderWrite(String path) {
+
+        return diskShare.openDirectory(path,
+                EnumSet.of(AccessMask.GENERIC_ALL),
+                EnumSet.of(FileAttributes.FILE_ATTRIBUTE_NORMAL),
+                EnumSet.of(SMB2ShareAccess.FILE_SHARE_READ),
+                SMB2CreateDisposition.FILE_OPEN_IF,
+                EnumSet.of(SMB2CreateOptions.FILE_DIRECTORY_FILE));
+    }
+
+    /**
+     * Returns a read handle on the file.
+     *
+     * @param path path to file
+     * @return DiskEntry file
+     */
+    public DiskEntry getDiskEntryRead(String path) {
+
+        return diskShare.open(path,
+                EnumSet.of(AccessMask.GENERIC_READ),
+                EnumSet.of(FileAttributes.FILE_ATTRIBUTE_NORMAL),
+                EnumSet.of(SMB2ShareAccess.FILE_SHARE_READ),
+                SMB2CreateDisposition.FILE_OPEN,
+                EnumSet.of(SMB2CreateOptions.FILE_NO_COMPRESSION));
+    }
+
+    /**
+     * Returns directory listing of path.
+     *
+     * @param path
+     * @return listing string array
+     */
+    public String[] getChildren(String path) {
+
+        List<String> children = new ArrayList<>();
+
+        for (FileIdBothDirectoryInformation file : diskShare.list(path)) {
+            String name = file.getFileName();
+            if (name.equals(".") || name.equals("..") || name.equals("./") || name.equals("../")) {
+                // ignore if there are no files in the directory and only relative path exists
+                continue;
+            }
+            children.add(file.getFileName());
+        }
+        return children.toArray(new String[children.size()]);
+    }
+
+    /**
+     * Delete item in given path of share.
+     *
+     * @param path string
+     * @throws FileSystemException
+     */
+    public void delete(String path) throws FileSystemException {
+
+        FileAllInformation info;
+        try {
+            info = diskShare.getFileInformation(path);
+        } catch (SMBApiException e) {
+            //file or folder does not exist
+            throw new FileSystemException("Could not delete file " + path);
+        }
+        if (info.getStandardInformation().isDirectory()) {
+            diskShare.rmdir(path, true);
+        } else {
+            diskShare.rm(path);
+        }
+    }
+}

--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2FileName.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2FileName.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.commons.vfs2.provider.smb2;
+
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileType;
+import org.apache.commons.vfs2.provider.GenericFileName;
+
+public class Smb2FileName extends GenericFileName {
+
+    private final String shareName;
+    private String rootUri;
+    private String uri;
+
+    protected Smb2FileName(String scheme, String hostName, int port, int defaultPort,
+                           String userName, String password, String path, FileType type, String shareName) {
+
+        super(scheme, hostName, port, defaultPort, userName, password, path, type);
+        this.shareName = shareName;
+        createURI();
+    }
+
+    /**
+     * Returns share name of the file.
+     *
+     * @return String share name
+     */
+    public String getShareName() {
+
+        return shareName;
+    }
+
+    @Override
+    public String getFriendlyURI() {
+
+        return createURI( false);
+    }
+
+    @Override
+    public String getURI() {
+
+        if (uri == null) {
+            uri = createURI();
+        }
+        return uri;
+    }
+
+    protected String createURI() {
+
+        return createURI(true);
+    }
+
+    /**
+     * Create URI with share name.
+     *
+     * @param usePassword
+     * @return uri
+     */
+    private String createURI(final boolean usePassword) {
+
+        StringBuilder sb = new StringBuilder();
+        appendRootUri(sb, usePassword);
+        if (sb.charAt(sb.length() - 1) != '/') {
+            sb.append('/');
+        }
+        sb.append(shareName);
+
+        if (!(getPath() == null || getPath().equals("/"))) {
+            if (!getPath().startsWith("/")) {
+                sb.append('/');
+            }
+            sb.append(getPath());
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public String getRootURI() {
+
+        if (this.rootUri == null) {
+            String uri = super.getRootURI();
+            this.rootUri = uri + shareName;
+        }
+        return this.rootUri;
+    }
+
+    @Override
+    public FileName getParent() {
+
+        if (this.rootUri == null) {
+            getRootURI();
+        }
+
+        if (getPath().replaceAll("/", "").equals(shareName) || getPath().equals("/") || getPath().equals("")) {
+            return null; //if this method is called from the root name, return null because there is no parent
+        } else {
+            return new Smb2FileName(this.getScheme(), this.getHostName(), this.getPort(),
+                    this.getDefaultPort(), this.getUserName(), this.getPassword(),
+                    getPath().substring(0, getPath().lastIndexOf("/")), this.getType(), shareName);
+        }
+    }
+}

--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2FileName.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2FileName.java
@@ -80,12 +80,12 @@ public class Smb2FileName extends GenericFileName {
             sb.append('/');
         }
         sb.append(shareName);
-
-        if (!(getPath() == null || getPath().equals("/"))) {
-            if (!getPath().startsWith("/")) {
+        String path = getPath();
+        if (!(path == null || path.equals("/"))) {
+            if (!path.startsWith("/")) {
                 sb.append('/');
             }
-            sb.append(getPath());
+            sb.append(path);
         }
         return sb.toString();
     }
@@ -106,13 +106,13 @@ public class Smb2FileName extends GenericFileName {
         if (this.rootUri == null) {
             getRootURI();
         }
-
-        if (getPath().replaceAll("/", "").equals(shareName) || getPath().equals("/") || getPath().equals("")) {
+        String path = getPath();
+        if (path.replaceAll("/", "").equals(shareName) || path.equals("/") || path.equals("")) {
             return null; //if this method is called from the root name, return null because there is no parent
         } else {
             return new Smb2FileName(this.getScheme(), this.getHostName(), this.getPort(),
                     this.getDefaultPort(), this.getUserName(), this.getPassword(),
-                    getPath().substring(0, getPath().lastIndexOf("/")), this.getType(), shareName);
+                    path.substring(0, path.lastIndexOf("/")), this.getType(), shareName);
         }
     }
 }

--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2FileNameParser.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2FileNameParser.java
@@ -50,8 +50,9 @@ public class Smb2FileNameParser extends HostFileNameParser {
      */
     protected String extractShareName(URI uri) throws FileSystemException {
 
-        String s = uri.getPath().startsWith("/") ? uri.getPath().substring(1) : uri.getPath();
-        String[] pathParts = s.split("/");
+        String path = uri.getPath();
+        path = path.startsWith("/") ? path.substring(1) : path;
+        String[] pathParts = path.split("/");
         String share = pathParts[0];
         if (share == null || share.isEmpty()) {
             throw new FileSystemException("vfs.provider.smb2/missing-share-name.error", uri.toString());

--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2FileNameParser.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2FileNameParser.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.commons.vfs2.provider.smb2;
+
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.provider.HostFileNameParser;
+import org.apache.commons.vfs2.provider.VfsComponentContext;
+
+import java.net.URI;
+
+public class Smb2FileNameParser extends HostFileNameParser {
+
+    private static final Smb2FileNameParser INSTANCE = new Smb2FileNameParser();
+    // default port for smb newer versions
+    private static final int PORT = 445;
+
+    protected Smb2FileNameParser() {
+
+        super(PORT);
+    }
+
+    public static Smb2FileNameParser getInstance() {
+
+        return INSTANCE;
+    }
+
+    /**
+     * Extracts the share share name from URI.
+     *
+     * @param uri
+     * @return share name String
+     * @throws FileSystemException
+     */
+    protected String extractShareName(URI uri) throws FileSystemException {
+
+        String s = uri.getPath().startsWith("/") ? uri.getPath().substring(1) : uri.getPath();
+        String[] pathParts = s.split("/");
+        String share = pathParts[0];
+        if (share == null || share.isEmpty()) {
+            throw new FileSystemException("vfs.provider.smb2/missing-share-name.error", uri.toString());
+        }
+        return pathParts[0];
+    }
+
+    @Override
+    public FileName parseUri(final VfsComponentContext context, final FileName base, final String uri) throws FileSystemException {
+
+        FileName parsedFileName = super.parseUri(context, base, uri);
+        String share;
+        if (base == null) {
+            share = extractShareName(parseURIString(parsedFileName.toString()));
+        } else {
+            share = extractShareName(parseURIString(base.toString()));
+        }
+
+        StringBuilder sb = new StringBuilder();
+        Authority auth = extractToPath(parsedFileName.toString(), sb);
+
+        String path;
+
+        if (sb.length() == 0 || (sb.length() == 1 && sb.charAt(0) == '/')) {
+            //this must point to the share root
+            path = "/" + share;
+        } else {
+            path = parsedFileName.getPath();
+        }
+
+        String relPathFromShare;
+        try {
+            relPathFromShare = removeShareFromAbsPath(path, share);
+        } catch (Exception e) {
+            throw new FileSystemException("vfs.provider.smb2/share-path-extraction.error", path, e.getCause());
+        }
+
+        return new Smb2FileName(auth.getScheme(), auth.getHostName(), auth.getPort(), PORT,
+                auth.getUserName(), auth.getPassword(), relPathFromShare, parsedFileName.getType(), share);
+    }
+
+    /**
+     * Parse string to URI.
+     *
+     * @param uriString uri
+     * @return URI for path
+     * @throws FileSystemException
+     */
+    public URI parseURIString(String uriString) throws FileSystemException {
+
+        try {
+            return new URI(uriString);
+        } catch (Exception e) {
+            throw new FileSystemException("vfs.provider.url/badly-formed-uri.error", uriString, e.getCause());
+        }
+    }
+
+    /**
+     * Remove share information from absolute path.
+     *
+     * @param path absolute path
+     * @param shareName String
+     * @return String
+     * @throws Exception
+     */
+    public String removeShareFromAbsPath(String path, String shareName) throws Exception {
+
+        if (shareName == null || shareName.length() == 0) {
+            throw new Exception("No path provided!");
+        }
+        String modifiedPath = path.startsWith("/") ? path.substring(1) : path;
+
+        if (!modifiedPath.substring(0, shareName.length()).equals(shareName)) {
+            throw new IllegalArgumentException("Share does not match the provided path");
+        }
+        modifiedPath = modifiedPath.substring(shareName.length());
+
+        if (modifiedPath.equals("") || modifiedPath.equals("/")) {
+            return "";
+        }
+        return modifiedPath;
+    }
+}

--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2FileObject.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2FileObject.java
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.commons.vfs2.provider.smb2;
+
+import com.hierynomus.msfscc.fileinformation.FileAllInformation;
+import com.hierynomus.smbj.share.DiskEntry;
+import com.hierynomus.smbj.share.File;
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileType;
+import org.apache.commons.vfs2.provider.AbstractFileName;
+import org.apache.commons.vfs2.provider.AbstractFileObject;
+import org.apache.commons.vfs2.provider.UriParser;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Class containing all its handles from the current Instance but NOT all
+ * possible handles to the same file (read/write separated)
+ */
+public class Smb2FileObject extends AbstractFileObject<Smb2FileSystem> {
+
+    private final String relPathToShare;
+    private FileAllInformation fileInfo;
+    private FileName rootName;
+    private DiskEntry diskEntryWrite;
+    private DiskEntry diskEntryRead;
+    private DiskEntry diskEntryFolderWrite;
+
+    /**
+     * @param name the file name - muse be an instance of {@link AbstractFileName}
+     * @param fileSystem the file system
+     * @throws ClassCastException if {@code name} is not an instance of {@link AbstractFileName}
+     */
+    protected Smb2FileObject(AbstractFileName name, Smb2FileSystem fileSystem, final FileName rootName) {
+
+        super(name, fileSystem);
+        String relPath = name.getURI().substring(rootName.getURI().length());
+        // smb shares do not accept "/" --> it needs a "\" which is represented by "\\"
+        relPathToShare = relPath.startsWith("/") ? relPath.substring(1).replace("/", "\\") : relPath.replace("/", "\\");
+        this.rootName = rootName;
+    }
+
+    @Override
+    protected long doGetContentSize() throws Exception {
+
+        getFileInfo();
+        return fileInfo.getStandardInformation().getEndOfFile();
+    }
+
+    @Override
+    protected InputStream doGetInputStream() throws Exception {
+
+        if (!getType().hasContent()) {
+            throw new FileSystemException("vfs.provider/read-not-file.error", getName());
+        }
+        if (diskEntryRead == null) {
+            getDiskEntryRead();
+        }
+        InputStream is = ((File) diskEntryRead).getInputStream();
+
+        // Wrapper will close the file object and input stream
+        return new Smb2InputStreamWrapper(is, this);
+    }
+
+    @Override
+    protected FileType doGetType() throws Exception {
+
+        synchronized (getFileSystem()) {
+            if (this.fileInfo == null) {
+                // returns null if the diskShare cannot fin the file info's. Therefore : imaginary
+                getFileInfo();
+            }
+            if (fileInfo == null) {
+                return FileType.IMAGINARY;
+            } else {
+                return (fileInfo.getStandardInformation().isDirectory()) ? FileType.FOLDER : FileType.FILE;
+            }
+        }
+    }
+
+    @Override
+    protected String[] doListChildren() throws Exception {
+
+        // do nothing here since doListChildrenResolved has been implemented
+        return null;
+    }
+
+    private void getFileInfo() {
+
+        if (fileInfo == null) {
+            synchronized (getFileSystem()) {
+                Smb2FileSystem fileSystem = (Smb2FileSystem) getFileSystem();
+                Smb2ClientWrapper client = (Smb2ClientWrapper) fileSystem.getClient();
+                try {
+                    fileInfo = client.getFileInfo(getRelPathToShare());
+                } finally {
+                    fileSystem.putClient(client);
+                }
+            }
+        }
+    }
+
+    @Override
+    public FileObject getParent() throws FileSystemException {
+
+        synchronized (getFileSystem()) {
+            AbstractFileName name = (AbstractFileName) getName().getParent();
+
+            // root folder has no parent
+            if (name == null) {
+                return null;
+            }
+            FileObject cachedFile = getFileSystem().getFileSystemManager().getFilesCache().getFile(getFileSystem(),
+                    name);
+            if (cachedFile != null) {
+                return cachedFile;
+            } else {
+                return new Smb2FileObject(name, (Smb2FileSystem) getFileSystem(), rootName);
+            }
+        }
+    }
+
+    @Override
+    protected OutputStream doGetOutputStream(final boolean bAppend) throws Exception {
+
+        if (diskEntryWrite == null) {
+            getDiskEntryWrite();
+        }
+
+        return ((File) diskEntryWrite).getOutputStream();
+    }
+
+    @Override
+    protected void doCreateFolder() throws Exception {
+
+        try {
+            synchronized (getFileSystem()) {
+                Smb2FileSystem fileSystem = (Smb2FileSystem) getFileSystem();
+                Smb2ClientWrapper client = (Smb2ClientWrapper) fileSystem.getClient();
+                try {
+                    client.createFolder(getRelPathToShare());
+                } finally {
+                    fileSystem.putClient(client);
+                }
+            }
+        } catch (Exception e) {
+            throw new FileSystemException("vfs.provider.smb2/folder-create.error", getName(), e.getCause());
+        }
+    }
+
+    @Override
+    protected void endOutput() throws Exception {
+
+        super.endOutput();
+        closeAllHandles();
+    }
+
+    /**
+     * Get file write handle.
+     *
+     * @throws FileSystemException handle create error
+     */
+    private void getDiskEntryWrite() throws FileSystemException {
+
+        closeAllHandles();
+        try {
+            synchronized (getFileSystem()) {
+                Smb2FileSystem fileSystem = (Smb2FileSystem) getFileSystem();
+                diskEntryWrite = fileSystem.getDiskEntryWrite(getRelPathToShare());
+            }
+        } catch (Exception e) {
+            throw new FileSystemException("vfs.provider.smb2/diskentry-create.error", getName(), e.getCause());
+        }
+    }
+
+    /**
+     * Get file read handle.
+     *
+     * @throws FileSystemException handle create error
+     */
+    private void getDiskEntryRead() throws FileSystemException {
+
+        try {
+            synchronized (getFileSystem()) {
+                Smb2FileSystem fileSystem = (Smb2FileSystem) getFileSystem();
+                diskEntryRead = fileSystem.getDiskEntryRead(getRelPathToShare());
+            }
+        } catch (Exception e) {
+            throw new FileSystemException("vfs.provider.smb2/diskentry-create.error", getName(), e.getCause());
+        }
+    }
+
+    /**
+     * Get directory write handle.
+     *
+     * @throws FileSystemException handle create error
+     */
+    private void getDiskEntryFolderWrite() throws FileSystemException {
+
+        try {
+            synchronized (getFileSystem()) {
+                Smb2FileSystem fileSystem = (Smb2FileSystem) getFileSystem();
+                diskEntryFolderWrite = fileSystem.getDiskEntryFolderWrite(getRelPathToShare());
+            }
+        } catch (Exception e) {
+            throw new FileSystemException("vfs.provider.smb2/diskentry-create.error", getName(), e.getCause());
+        }
+    }
+
+    /**
+     * Returns relative path to share.
+     *
+     * @return string
+     */
+    public String getRelPathToShare() {
+
+        return decodeOrGet(relPathToShare);
+    }
+
+    /**
+     * Decode URI value.
+     *
+     * @param value uri
+     * @return decoded path ot path
+     */
+    public String decodeOrGet(String value) {
+
+        try {
+            return UriParser.decode(value);
+        } catch (FileSystemException e) {
+            return value;
+        }
+    }
+
+    @Override
+    protected void doRename(final FileObject newFile) throws Exception {
+
+        Smb2FileObject fileObject = (Smb2FileObject) newFile;
+        if (doGetType() == FileType.FOLDER) {
+            if (diskEntryFolderWrite == null) {
+                getDiskEntryFolderWrite();
+            }
+            diskEntryFolderWrite.rename(fileObject.getRelPathToShare());
+        } else {
+            if (diskEntryWrite == null) {
+                getDiskEntryWrite();
+            }
+            diskEntryWrite.rename(fileObject.getRelPathToShare());
+            closeAllHandles();
+        }
+    }
+
+    @Override
+    protected FileObject[] doListChildrenResolved() throws Exception {
+
+        synchronized (getFileSystem()) {
+            if (getType() != FileType.FOLDER) {
+                throw new FileSystemException("vfs.provider/list-children-not-folder.error", this);
+            }
+
+            List<FileObject> children = new ArrayList<>();
+
+            Smb2FileSystem fileSystem = (Smb2FileSystem) getFileSystem();
+            Smb2ClientWrapper client = (Smb2ClientWrapper) fileSystem.getClient();
+            String[] childrenNames;
+            try {
+                childrenNames = client.getChildren(getRelPathToShare());
+            } finally {
+                fileSystem.putClient(client);
+            }
+
+            for (String child : childrenNames) {
+                children.add(fileSystem.getFileSystemManager().resolveFile(this, UriParser.encode(child)));
+            }
+            return children.toArray(new FileObject[children.size()]);
+        }
+    }
+
+    @Override
+    protected void doDelete() throws Exception {
+
+        synchronized (getFileSystem()) {
+            if (diskEntryRead != null) {
+                diskEntryRead.close();
+            }
+            endOutput();
+
+            Smb2FileSystem fileSystem = (Smb2FileSystem) getFileSystem();
+            Smb2ClientWrapper client = (Smb2ClientWrapper) fileSystem.getClient();
+            try {
+                client.delete(getRelPathToShare());
+            } finally {
+                fileSystem.putClient(client);
+            }
+        }
+    }
+
+    @Override
+    protected long doGetLastModifiedTime() throws Exception {
+
+        getFileInfo();
+        return fileInfo.getBasicInformation().getChangeTime().getWindowsTimeStamp();
+    }
+
+    @Override
+    public void close() throws FileSystemException {
+
+        super.close();
+        closeAllHandles();
+    }
+
+    /**
+     * Closes DiskEntry Objects.
+     */
+    private void closeAllHandles() {
+
+        if (diskEntryRead != null) {
+            diskEntryRead.close();
+            diskEntryRead = null;
+        }
+        if (diskEntryWrite != null) {
+            diskEntryWrite.close();
+            diskEntryWrite = null;
+        }
+    }
+
+    @Override
+    protected void doDetach() {
+
+        this.fileInfo = null;
+    }
+
+    @Override
+    public String toString() {
+
+        return getName().toString();
+    }
+
+    @Override
+    public boolean doSetLastModifiedTime(final long modTime) {
+
+        // Cannot create a FileAllInformation object to override information.
+        // Hence do nothing and return true
+        return true;
+    }
+}

--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2FileProvider.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2FileProvider.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.commons.vfs2.provider.smb2;
+
+import org.apache.commons.vfs2.Capability;
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileSystem;
+import org.apache.commons.vfs2.FileSystemException;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.UserAuthenticationData;
+import org.apache.commons.vfs2.provider.AbstractOriginatingFileProvider;
+import org.apache.commons.vfs2.provider.GenericFileName;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+public class Smb2FileProvider extends AbstractOriginatingFileProvider {
+
+    /**
+     * Authenticator types.
+     */
+    public static final UserAuthenticationData.Type[] AUTHENTICATOR_TYPES = new UserAuthenticationData.Type[]
+            {UserAuthenticationData.USERNAME, UserAuthenticationData.PASSWORD};
+
+    static final Collection<Capability> capabilities = Collections.unmodifiableCollection(Arrays.asList(
+            Capability.CREATE, Capability.DELETE, Capability.RENAME, Capability.GET_TYPE, Capability.LIST_CHILDREN,
+            Capability.READ_CONTENT, Capability.GET_LAST_MODIFIED, Capability.URI, Capability.WRITE_CONTENT));
+
+    public Smb2FileProvider() {
+
+        super();
+        setFileNameParser(Smb2FileNameParser.getInstance());
+    }
+
+    @Override
+    protected FileSystem doCreateFileSystem(FileName name, FileSystemOptions fileSystemOptions) throws FileSystemException {
+
+        final GenericFileName rootName = (GenericFileName) name;
+        final Smb2ClientWrapper smbClient = new Smb2ClientWrapper(rootName, fileSystemOptions);
+        return new Smb2FileSystem(rootName, fileSystemOptions, smbClient);
+    }
+
+    @Override
+    public Collection<Capability> getCapabilities() {
+
+        return capabilities;
+    }
+
+    @Override
+    public FileName parseUri(final FileName base, final String uri) throws FileSystemException {
+
+        if (getFileNameParser() != null) {
+            return getFileNameParser().parseUri(getContext(), base, uri);
+        }
+        throw new FileSystemException("vfs.provider/filename-parser-missing.error");
+    }
+}

--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2FileSystem.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2FileSystem.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.commons.vfs2.provider.smb2;
+
+import com.hierynomus.smbj.SMBClient;
+import com.hierynomus.smbj.share.DiskEntry;
+import org.apache.commons.vfs2.Capability;
+import org.apache.commons.vfs2.FileName;
+import org.apache.commons.vfs2.FileObject;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.provider.AbstractFileName;
+import org.apache.commons.vfs2.provider.AbstractFileSystem;
+
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class Smb2FileSystem extends AbstractFileSystem {
+
+    // making the client thread safe
+    private final AtomicReference<SMBClient> client = new AtomicReference<>();
+
+    protected Smb2FileSystem(FileName rootName, FileSystemOptions fileSystemOptions, SMBClient smbClient) {
+
+        super(rootName, null, fileSystemOptions);
+        client.set(smbClient);
+    }
+
+    @Override
+    protected FileObject createFile(AbstractFileName name) {
+
+        return new Smb2FileObject(name, this, getRootName());
+    }
+
+    @Override
+    protected void addCapabilities(Collection<Capability> caps) {
+
+        caps.addAll(Smb2FileProvider.capabilities);
+    }
+
+    /**
+     * Returns the SMB client thread safe.
+     *
+     * @return SMBClient
+     */
+    public SMBClient getClient() {
+
+        return client.getAndSet(null);
+    }
+
+    /**
+     * Set the smbclient back to atomic reference.
+     *
+     * @param smbClient
+     */
+    public void putClient(SMBClient smbClient) {
+
+        client.set(smbClient);
+    }
+
+    /**
+     * Get write handle for file.
+     *
+     * @param path file path
+     * @return DiskEntry
+     */
+    public DiskEntry getDiskEntryWrite(String path) {
+
+        return ((Smb2ClientWrapper) client.get()).getDiskEntryWrite(path);
+    }
+
+    /**
+     * Get read handle for file.
+     *
+     * @param path file path
+     * @return DiskEntry
+     */
+    public DiskEntry getDiskEntryRead(String path) {
+
+        return ((Smb2ClientWrapper) client.get()).getDiskEntryRead(path);
+    }
+
+    /**
+     * Returns the write handle to folder.
+     *
+     * @param path folder path
+     * @return DiskEntry
+     */
+    public DiskEntry getDiskEntryFolderWrite(String path) {
+
+        return ((Smb2ClientWrapper) client.get()).getDiskEntryFolderWrite(path);
+    }
+}

--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2InputStreamWrapper.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2InputStreamWrapper.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.commons.vfs2.provider.smb2;
+
+import org.apache.commons.vfs2.FileObject;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * This class wraps the InputStream ana vfs FileObject.
+ * Used to close inputstream and fileobject
+ */
+public class Smb2InputStreamWrapper extends InputStream {
+
+    private InputStream inputStream;
+    private final FileObject fileObject;
+
+    public Smb2InputStreamWrapper(InputStream inputStream, final FileObject fileObject) {
+
+        this.inputStream = inputStream;
+        this.fileObject = fileObject;
+    }
+
+    @Override
+    public int read() throws IOException {
+
+        return inputStream.read();
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        inputStream.close();
+        fileObject.close();
+    }
+}

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/Resources.properties
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/Resources.properties
@@ -203,6 +203,13 @@ vfs.provider.temp/missing-share-name.error=Share name missing from UNC file name
 vfs.provider.smb/missing-share-name.error=The share name is missing from URI "{0}".
 vfs.provider.smb/get-type.error=Could not detemine the type of "{0}".
 
+# SMB2 Provider
+vfs.provider.smb2/missing-share-name.error=The share name is missing from URI "{0}".
+vfs.provider.smb2/share-path-extraction.error=Share name extraction failed for path "{0}".
+vfs.provider.smb2/connect.error=Could not establish connection to "{0}".
+vfs.provider.smb2/folder-create.error=Could not create folder "{0}".
+vfs.provider.smb2/diskentry-create.error=Could not create a handle for file "{0}".
+
 # Zip Provider
 vfs.provider.zip/open-zip-file.error=Could not open Zip file "{0}".
 vfs.provider.zip/close-zip-file.error=Could not close Zip file "{0}".

--- a/orbit/resources/META-INF/vfs-providers.xml
+++ b/orbit/resources/META-INF/vfs-providers.xml
@@ -21,7 +21,11 @@
 		<scheme name="smb"/>
 		<if-available class-name="jcifs.smb.SmbFile"/>
 	</provider>
-	
+
+	<provider class-name="org.apache.commons.vfs2.provider.smb2.Smb2FileProvider">
+		<scheme name="smb2"/>
+	</provider>
+
 	<provider class-name="org.apache.commons.vfs2.provider.mime.MimeFileProvider">
 		<scheme name="mime"/>
 		<if-available class-name="javax.mail.internet.MimeMultipart"/>

--- a/pom.xml
+++ b/pom.xml
@@ -386,6 +386,11 @@
         <version>1.3.17</version>
       </dependency>
       <dependency>
+        <groupId>com.hierynomus.wso2</groupId>
+        <artifactId>smbj</artifactId>
+        <version>0.10.0.wso2v1</version>
+      </dependency>
+      <dependency>
         <groupId>javax.mail</groupId>
         <artifactId>mail</artifactId>
         <version>1.4.7</version>

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,7 @@
     <hadoop.version>2.6.0</hadoop.version>
     <checkstyle.skip>true</checkstyle.skip>
     <findbugs.skip>true</findbugs.skip>
+    <hierynomus.wso2.smbj.version>0.10.0.wso2v1</hierynomus.wso2.smbj.version>
   </properties>
 
   <build>
@@ -388,7 +389,7 @@
       <dependency>
         <groupId>com.hierynomus.wso2</groupId>
         <artifactId>smbj</artifactId>
-        <version>0.10.0.wso2v1</version>
+        <version>${hierynomus.wso2.smbj.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.mail</groupId>
@@ -550,5 +551,4 @@
     </profile>
 
   </profiles>
-
 </project>


### PR DESCRIPTION
## Purpose
- Add SMB2 support for VFS trasnport
- New scheme has been introduced with smb2. 
- This scheme can be used for both smb v2/3 scenarios.
- For reference: https://docs.microsoft.com/en-us/windows-server/storage/file-server/troubleshoot/detect-enable-and-disable-smbv1-v2-v3

```
smb2://USER:PASSWORD@192.168.1.9:445/SMBFileShare/in
```