### PR TITLE
Add transport.vfs.UpdateLastModified property to VFS.

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/FileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/FileObject.java
@@ -82,9 +82,16 @@ public interface FileObject extends Comparable<FileObject>, Iterable<FileObject>
      */
     boolean canRenameTo(FileObject newfile);
 
+    /**
+     * Set flag to manage setting last modified timestamo
+     * @param updateLastModified boolean. True if last modified needs to be updated.
+     */
+    void setUpdateLastModified(boolean updateLastModified);
 
-    void setUpdateLastModified(boolean value);
-
+    /**
+     * Returns the true if last modified timestamp has to be updated
+     * @return boolean
+     */
     boolean getUpdateLastModified();
 
     /**

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/FileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/FileObject.java
@@ -82,6 +82,11 @@ public interface FileObject extends Comparable<FileObject>, Iterable<FileObject>
      */
     boolean canRenameTo(FileObject newfile);
 
+
+    void setUpdateLastModified(boolean value);
+
+    boolean getUpdateLastModified();
+
     /**
      * Closes this file, and its content. This method is a hint to the implementation that it can release any resources
      * associated with the file.

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DecoratedFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DecoratedFileObject.java
@@ -47,6 +47,16 @@ public class DecoratedFileObject implements FileObject {
     }
 
     @Override
+    public void setUpdateLastModified(boolean value) {
+        // do nothing
+    }
+
+    @Override
+    public boolean getUpdateLastModified() {
+        return false;
+    }
+
+    @Override
     public void close() throws FileSystemException {
         decoratedFileObject.close();
     }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DecoratedFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DecoratedFileObject.java
@@ -48,12 +48,12 @@ public class DecoratedFileObject implements FileObject {
 
     @Override
     public void setUpdateLastModified(boolean value) {
-        // do nothing
+        decoratedFileObject.setUpdateLastModified(value);
     }
 
     @Override
     public boolean getUpdateLastModified() {
-        return false;
+        return decoratedFileObject.getUpdateLastModified();
     }
 
     @Override

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
@@ -86,6 +86,8 @@ public abstract class AbstractFileObject<AFS extends AbstractFileSystem> impleme
 
     private List<Object> objects;
 
+    private boolean updateLastModified;
+
     /**
      * FileServices instance.
      */
@@ -100,7 +102,16 @@ public abstract class AbstractFileObject<AFS extends AbstractFileSystem> impleme
     protected AbstractFileObject(final AbstractFileName name, final AFS fs) {
         this.fileName = name;
         this.fs = fs;
+        this.updateLastModified = true;
         fs.fileObjectHanded(this);
+    }
+
+    public boolean getUpdateLastModified() {
+        return updateLastModified;
+    }
+
+    public void setUpdateLastModified(boolean setLastModified) {
+        this.updateLastModified = setLastModified;
     }
 
     /**
@@ -1608,7 +1619,7 @@ public abstract class AbstractFileObject<AFS extends AbstractFileSystem> impleme
 
             destFile.copyFrom(this, Selectors.SELECT_SELF);
 
-            if ((destFile.getType().hasContent()
+            if (destFile.getUpdateLastModified() && (destFile.getType().hasContent()
                     && destFile.getFileSystem().hasCapability(Capability.SET_LAST_MODIFIED_FILE)
                     || destFile.getType().hasChildren()
                             && destFile.getFileSystem().hasCapability(Capability.SET_LAST_MODIFIED_FOLDER))

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
@@ -110,8 +110,8 @@ public abstract class AbstractFileObject<AFS extends AbstractFileSystem> impleme
         return updateLastModified;
     }
 
-    public void setUpdateLastModified(boolean setLastModified) {
-        this.updateLastModified = setLastModified;
+    public void setUpdateLastModified(boolean updateLastModified) {
+        this.updateLastModified = updateLastModified;
     }
 
     /**


### PR DESCRIPTION
## Purpose
For cases where the last modified time stamp needs to be ignored, use the property as follows. Default value of this parameter is true, hence timestamp will be set by default

```
<parameter name="transport.vfs.UpdateLastModified">false</parameter>
```

Fixes: wso2/micro-integrator#2318