### PR TITLE
Add Strict Host Key Check parameter as a VFS URL parameter

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
@@ -735,6 +735,13 @@ public class DefaultFileSystemManager implements FileSystemManager {
                             .setUserDirIsRoot(fileSystemOptions, false);
                 }
 
+                String strictHostKeyChecking = queryParam.get(SftpConstants.STRICT_HOST_KEY_CHECKING);
+
+                if (strictHostKeyChecking != null) {
+                    ((SftpFileSystemConfigBuilder) (provider.getConfigBuilder()))
+                            .setStrictHostKeyChecking(fileSystemOptions, strictHostKeyChecking);
+                }
+
                 String proxyHost = queryParam.get(SftpConstants.PROXY_SERVER);
 
                 if (proxyHost != null && !proxyHost.isEmpty()) {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpConstants.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpConstants.java
@@ -53,4 +53,9 @@ public interface SftpConstants {
     /** Denote SOCKS proxy type. */
     String SOCKS = "socks";
 
+    /**
+     * Specifies whether the Host key should be checked. If set to 'yes', the connector (JSch) will always verify
+     * the public key (fingerprint) of the SSH/SFTP server.
+     **/
+    String STRICT_HOST_KEY_CHECKING = "transport.vfs.StrictHostKeyChecking";
 }


### PR DESCRIPTION
## Purpose

Currently, in MI there is no option to enable or disable StrictHostKeyChecking. The expected behaviour is to validate known hosts when the StrictHostKeyChecking config is yes.

Example,
```xml
<parameter name="transport.vfs.FileURI">vfs:ftps://test:test123@10.20.2.63/vfs/in?transport.vfs.StrictHostKeyChecking=yes</parameter>
```

Possible values,

yes, no(default) or ask

Fixes: https://github.com/wso2/api-manager/issues/1436