### PR TITLE
Remove the query params when creating a local file name

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/local/GenericFileNameParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/local/GenericFileNameParser.java
@@ -60,4 +60,11 @@ public class GenericFileNameParser extends LocalFileNameParser {
             final FileType type) {
         return new LocalFileName(scheme, "", path, type);
     }
+
+    @Override
+    protected FileName createFileName(String scheme, String rootFile, String path, FileType type,
+                                      String queryString) {
+
+        return new LocalFileName(scheme, "", path, type, queryString);
+    }
 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/local/LocalFileName.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/local/LocalFileName.java
@@ -42,9 +42,18 @@ public class LocalFileName extends AbstractFileName {
 
     private final String rootFile;
 
+    private String queryString;
+
     protected LocalFileName(final String scheme, final String rootFile, final String path, final FileType type) {
         super(scheme, path, type);
         this.rootFile = rootFile;
+    }
+
+    protected LocalFileName(final String scheme, final String rootFile, final String path, final FileType type,
+                            final String queryString) {
+
+        this(scheme, rootFile, path, type);
+        this.queryString = queryString;
     }
 
     /**
@@ -114,6 +123,19 @@ public class LocalFileName extends AbstractFileName {
         }
 
         return uri;
+    }
+
+    @Override
+    protected String createURI() {
+
+        if (queryString != null) {
+            final StringBuilder sb = new StringBuilder();
+            sb.append(super.createURI());
+            sb.append("?");
+            sb.append(queryString);
+            return sb.toString();
+        }
+        return super.createURI();
     }
 
     /**

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/local/LocalFileNameParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/local/LocalFileNameParser.java
@@ -66,6 +66,9 @@ public abstract class LocalFileNameParser extends AbstractFileNameParser {
             scheme = "file";
         }
 
+        // Extract the queryString
+        final String queryString = UriParser.extractQueryString(name);
+
         // Remove encoding, and adjust the separators
         UriParser.canonicalizePath(name, 0, name.length(), this);
 
@@ -79,9 +82,12 @@ public abstract class LocalFileNameParser extends AbstractFileNameParser {
 
         final String path = name.toString();
 
-        return createFileName(scheme, rootFile, path, fileType);
+        return createFileName(scheme, rootFile, path, fileType, queryString);
     }
 
     protected abstract FileName createFileName(String scheme, final String rootFile, final String path,
             final FileType type);
+
+    protected abstract FileName createFileName(String scheme, final String rootFile, final String path,
+                                               final FileType type, final String queryString);
 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/local/WindowsFileName.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/local/WindowsFileName.java
@@ -27,6 +27,11 @@ public class WindowsFileName extends LocalFileName {
         super(scheme, rootFile, path, type);
     }
 
+    protected WindowsFileName(final String scheme, final String rootFile, final String path, final FileType type,
+                              final String queryString) {
+        super(scheme, rootFile, path, type, queryString);
+    }
+
     /**
      * Factory method for creating name instances.
      *

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/local/WindowsFileNameParser.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/local/WindowsFileNameParser.java
@@ -38,6 +38,13 @@ public class WindowsFileNameParser extends LocalFileNameParser {
         return new WindowsFileName(scheme, rootFile, path, type);
     }
 
+    @Override
+    protected FileName createFileName(String scheme, String rootFile, String path, FileType type,
+                                      String queryString) {
+
+        return new WindowsFileName(scheme, rootFile, path, type, queryString);
+    }
+
     /**
      * Extracts a Windows root prefix from a name.
      */


### PR DESCRIPTION
## Purpose

Remove the query params when creating a local file name

When VFS Sender was used for local file transfers the query parameters were appended to the output filename. With this fix, the query parameters will be extracted and appended only for the URI.

Fixes: https://github.com/wso2/api-manager/issues/1909