### PR TITLE
Considering FSO params when setting the values

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpClientFactory.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpClientFactory.java
@@ -133,21 +133,30 @@ public final class FtpClientFactory {
                 password = ANON_CHAR_ARRAY;
             }
 
-            Integer connectionTimeout = null;
-            try {
-                connectionTimeout = Integer.parseInt(timeout);
-            } catch (NumberFormatException nfe) {
-                log.warn("Invalid connection timeout " + timeout + ". Set the connectionTimeout as 5000. (default)");
-                connectionTimeout = 5000;
+            Integer connectionTimeout;
+
+            if (timeout == null) {
+                connectionTimeout = builder.getConnectTimeout(fileSystemOptions);
+            } else {
+                try {
+                    connectionTimeout = Integer.parseInt(timeout);
+                } catch (NumberFormatException nfe) {
+                    log.warn("Invalid connection timeout " + timeout + ". Set the connectionTimeout as 5000. (default)");
+                    connectionTimeout = 5000;
+                }
             }
 
-            Integer connectionRetryCount = null;
-            try {
-                connectionRetryCount = Integer.parseInt(retryCount);
-            } catch (NumberFormatException e) {
-                log.warn("Invalid connection retry count " + retryCount + ". Set the connectionRetryCount as 5. "
-                        + "(default)");
-                connectionRetryCount = 5;
+            Integer connectionRetryCount;
+            if (retryCount == null) {
+                connectionRetryCount = builder.getRetryCount(fileSystemOptions);
+            } else {
+                try {
+                    connectionRetryCount = Integer.parseInt(retryCount);
+                } catch (NumberFormatException nfe) {
+                    log.warn("Invalid connection retry count " + retryCount + ". Set the connectionRetryCount as 5. "
+                            + "(default)");
+                    connectionRetryCount = 5;
+                }
             }
 
             boolean proxyMode = false;

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpFileSystemConfigBuilder.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpFileSystemConfigBuilder.java
@@ -32,6 +32,7 @@ public class FtpFileSystemConfigBuilder extends FileSystemConfigBuilder {
     private static final FtpFileSystemConfigBuilder BUILDER = new FtpFileSystemConfigBuilder();
 
     private static final String CONNECT_TIMEOUT = _PREFIX + ".CONNECT_TIMEOUT";
+    private static final String RETRY_COUNT = _PREFIX + ".RETRY_COUNT";
     private static final String DATA_TIMEOUT = _PREFIX + ".DATA_TIMEOUT";
     private static final String DEFAULT_DATE_FORMAT = _PREFIX + ".DEFAULT_DATE_FORMAT";
     private static final String ENCODING = _PREFIX + ".ENCODING";
@@ -84,6 +85,17 @@ public class FtpFileSystemConfigBuilder extends FileSystemConfigBuilder {
      */
     public Integer getConnectTimeout(final FileSystemOptions opts) {
         return getInteger(opts, CONNECT_TIMEOUT);
+    }
+
+    /**
+     * Gets the retry count.
+     *
+     * @param opts The FileSystemOptions.
+     * @return The retry count.
+     * @since 2.1
+     */
+    public Integer getRetryCount(final FileSystemOptions opts) {
+        return getInteger(opts, RETRY_COUNT);
     }
 
     /**
@@ -249,6 +261,17 @@ public class FtpFileSystemConfigBuilder extends FileSystemConfigBuilder {
      */
     public void setConnectTimeout(final FileSystemOptions opts, final Integer connectTimeout) {
         setParam(opts, CONNECT_TIMEOUT, connectTimeout);
+    }
+
+    /**
+     * Sets the number of retries.
+     *
+     * @param opts The FileSystemOptions.
+     * @param retryCount the retryCount value.
+     * @since 2.1
+     */
+    public void setRetryCount(final FileSystemOptions opts, final Integer retryCount) {
+        setParam(opts, RETRY_COUNT, retryCount);
     }
 
     /**


### PR DESCRIPTION


## Purpose
Previously we were not considering FSO params when setting the values (only considering the query params) of FileConnectors

Fixes: https://github.com/wso2/api-manager/issues/1969