### PR TITLE
add nexus release repos to 2.2.x branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -529,6 +529,19 @@
     <!--</site>-->
   <!--</distributionManagement>-->
 
+  <distributionManagement>
+    <repository>
+      <id>nexus-releases</id>
+      <name>WSO2 Release Distribution Repository</name>
+      <url>http://maven.wso2.org/nexus/service/local/staging/deploy/maven2/</url>
+    </repository>
+    <snapshotRepository>
+      <id>wso2.snapshots</id>
+      <name>Apache Snapshot Repository</name>
+      <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+    </snapshotRepository>
+  </distributionManagement>
+  
   <!-- Releasing VFS as a multi-module build with binary artifacts is somewhat painful. This profile hooks into the commons-parent
     and the apache-pom to get the build done and then uses the assembly to package it up. -->
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -521,27 +521,19 @@
     </dependencies>
   </dependencyManagement>
 
-  <!--<distributionManagement>-->
-    <!--<site>-->
-      <!--<id>commons.site</id>-->
-      <!--<name>Apache Commons Site</name>-->
-      <!--<url>scm:svn:${commons.scmPubUrl}</url>-->
-    <!--</site>-->
-  <!--</distributionManagement>-->
-
   <distributionManagement>
     <repository>
       <id>nexus-releases</id>
       <name>WSO2 Release Distribution Repository</name>
-      <url>http://maven.wso2.org/nexus/service/local/staging/deploy/maven2/</url>
+      <url>https://maven.wso2.org/nexus/service/local/staging/deploy/maven2/</url>
     </repository>
     <snapshotRepository>
       <id>wso2.snapshots</id>
       <name>Apache Snapshot Repository</name>
-      <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+      <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
     </snapshotRepository>
   </distributionManagement>
-  
+
   <!-- Releasing VFS as a multi-module build with binary artifacts is somewhat painful. This profile hooks into the commons-parent
     and the apache-pom to get the build done and then uses the assembly to package it up. -->
   <profiles>


### PR DESCRIPTION
## Purpose
> To fix Jenkins build failure as it tries to push to an htp address instead of https
