### PR TITLE
Update the URL pattern regex to correctly mask the SMB2 passwords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # ignore target directories
 target/
+
+.DS_Store

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/FileSystemException.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/FileSystemException.java
@@ -32,7 +32,7 @@ public class FileSystemException extends IOException {
     private static final long serialVersionUID = 20101208L;
 
     /** URL pattern */
-    private static final Pattern URL_PATTERN = Pattern.compile("[a-z]+://.*");
+    private static final Pattern URL_PATTERN = Pattern.compile("[a-zA-Z0-9]+://.*");
 
     /** Password pattern */
     private static final Pattern PASSWORD_PATTERN = Pattern.compile(":(?:[^/]+)@");


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Since the existing URL pattern regex does not capture the numeric characters, it fails to match the smb2 URL that has a numeric character in it. Therefore, the password masking mechanism does not work as intended. This PR updates the URL pattern regex accordingly to overcome this issue.

Fixes wso2/product-ei#5522