### PR TITLE
Improve FileSystemManager Implementation to consider timeout parameter defined in URL

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
@@ -730,6 +730,17 @@ public class DefaultFileSystemManager implements FileSystemManager {
                     builder.setAvoidPermissionCheck(fileSystemOptions, permissionCheck);
                 }
 
+                String timeoutStr = queryParam.get(SftpConstants.TIMEOUT);
+                Integer timeout = null;
+                if (timeoutStr != null && builder.getTimeout(fileSystemOptions) == null) {
+                    try {
+                        timeout = Integer.parseInt(timeoutStr);
+                    } catch (NumberFormatException e) {
+                        log.warn("Invalid timeout " + timeoutStr + " specified in FileURI.");
+                    }
+                    builder.setTimeout(fileSystemOptions, timeout);
+                }
+
                 if ("true".equals(queryParam.get(SftpConstants.SFTP_PATH_FROM_ROOT))) {
                     ((SftpFileSystemConfigBuilder) (((SftpFileProvider) provider).getConfigBuilder()))
                             .setUserDirIsRoot(fileSystemOptions, false);


### PR DESCRIPTION
Resolves wso2/api-manager#2434

Currently, if the timeout is defined in the URL, it is not considered and added to FileSystemOptions. This fix will improve the implementation to consider timeout defined in URL.