### PR TITLE
Fix connection growing issue in SMB2 path

### DIFF
--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2ClientWrapper.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2ClientWrapper.java
@@ -104,16 +104,7 @@ public class Smb2ClientWrapper extends SMBClient {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Error while creating connection to " + rootName.getHostName());
             }
-            try {
-                if (session != null) {
-                    session.close();
-                }
-                if (connection != null) {
-                    connection.close();
-                }
-            } catch (IOException ignored) {
-
-            }
+            close();
             throw new FileSystemException("vfs.provider.smb2/connect.error", rootName.getHostName(), e);
         }
     }
@@ -243,6 +234,33 @@ public class Smb2ClientWrapper extends SMBClient {
             diskShare.rmdir(path, true);
         } else {
             diskShare.rm(path);
+        }
+    }
+
+    public void close() {
+        try {
+            if (diskShare != null) {
+                diskShare.close();
+            }
+            if (session != null) {
+                session.close();
+            }
+            if (connection != null) {
+                connection.close(true);
+            }
+        } catch (Exception e) {
+            LOG.debug("Error while closing the connection.", e);
+        } finally {
+            if (connection != null) {
+                try {
+                    LOG.debug("Connection closed forcefully for : " + smbClient);
+                    connection.close(true);
+                } catch (IOException e) {
+                    //Ignore
+                }
+            }
+            // Close the client
+            super.close();
         }
     }
 }

--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2FileSystem.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2FileSystem.java
@@ -95,10 +95,10 @@ public class Smb2FileSystem extends AbstractFileSystem {
      */
     public void putClient(SMBClient smbClient) {
         if (isClosed) {
-            smbClient.close();
+            ((Smb2ClientWrapper)smbClient).close();
         } else if (!client.compareAndSet(null, smbClient)) {
             // An idle client is already present so close the connection.
-            smbClient.close();
+            ((Smb2ClientWrapper)smbClient).close();
         }
     }
 }


### PR DESCRIPTION


## Purpose
The architecture of the SMB2 path is to define indefinite number of SMB2Clients in a concurrent situation but when handing over just manage a single reference by using a atomic variable and closing others. Here the issue was we were closing the SMBClient yet since underlying resources are utilized the connections were not closed properly. Hence fixed that.

Fixes: https://github.com/wso2/micro-integrator/issues/3295