### PR TITLE
Add transport.vfs.IsMounted property to VFS

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/FileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/FileObject.java
@@ -95,6 +95,18 @@ public interface FileObject extends Comparable<FileObject>, Iterable<FileObject>
     boolean getUpdateLastModified();
 
     /**
+     * Set volume mounted
+     * @param isMounted
+     */
+    void setIsMounted(boolean isMounted);
+
+    /**
+     * Check if volume mounted
+     * @return boolean
+     */
+    boolean getIsMounted();
+
+    /**
      * Closes this file, and its content. This method is a hint to the implementation that it can release any resources
      * associated with the file.
      * <p>

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DecoratedFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DecoratedFileObject.java
@@ -57,6 +57,15 @@ public class DecoratedFileObject implements FileObject {
     }
 
     @Override
+    public boolean getIsMounted() {
+        return decoratedFileObject.getIsMounted();
+    }
+
+    @Override
+    public void setIsMounted(boolean isMounted) {
+        decoratedFileObject.setIsMounted(isMounted);
+    }
+    @Override
     public void close() throws FileSystemException {
         decoratedFileObject.close();
     }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
@@ -87,6 +87,7 @@ public abstract class AbstractFileObject<AFS extends AbstractFileSystem> impleme
     private List<Object> objects;
 
     private boolean updateLastModified;
+    private boolean isMounted;
 
     /**
      * FileServices instance.
@@ -103,6 +104,7 @@ public abstract class AbstractFileObject<AFS extends AbstractFileSystem> impleme
         this.fileName = name;
         this.fs = fs;
         this.updateLastModified = true;
+        this.isMounted = false;
         fs.fileObjectHanded(this);
     }
 
@@ -112,6 +114,14 @@ public abstract class AbstractFileObject<AFS extends AbstractFileSystem> impleme
 
     public void setUpdateLastModified(boolean updateLastModified) {
         this.updateLastModified = updateLastModified;
+    }
+
+    public boolean getIsMounted() {
+        return isMounted;
+    }
+
+    public void setIsMounted(boolean isMounted) {
+        this.isMounted = isMounted;
     }
 
     /**
@@ -188,6 +198,10 @@ public abstract class AbstractFileObject<AFS extends AbstractFileSystem> impleme
      */
     @Override
     public boolean canRenameTo(final FileObject newfile) {
+        // If volume mounted, it is considered as two different file systems, hence cannot rename.
+        if (newfile.getIsMounted()) {
+            return false;
+        }
         return fs == newfile.getFileSystem();
     }
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/AbstractFileObject.java
@@ -199,7 +199,7 @@ public abstract class AbstractFileObject<AFS extends AbstractFileSystem> impleme
     @Override
     public boolean canRenameTo(final FileObject newfile) {
         // If volume mounted, it is considered as two different file systems, hence cannot rename.
-        if (newfile.getIsMounted()) {
+        if (this.getIsMounted() || newfile.getIsMounted()) {
             return false;
         }
         return fs == newfile.getFileSystem();


### PR DESCRIPTION
## Description:
Add `transport.vfs.IsMounted` property to VFS which can be configured as a query parameter for `transport.vfs.FileURI`, `transport.vfs.MoveAfterProces` and `transport.vfs.MoveAfterFailure`. This needs to be set to `true` when a file read/write location is a bind mount volume.

Example:
```
<parameter name="transport.vfs.FileURI">file:///home/wso2carbon/tmp/in?transport.vfs.IsMounted=true</parameter>  
<parameter name="transport.vfs.MoveAfterProcess">file:///home/wso2carbon/tmp/archive?transport.vfs.IsMounted=true</parameter>
<parameter name="transport.vfs.MoveAfterFailure">file:///home/wso2carbon/tmp/bar?transport.vfs.IsMounted=true</parameter>
    
```


Fixes: https://github.com/wso2/micro-integrator/issues/3308