### PR TITLE
Returning null from doListChildren() method if the file isn't a directory with children being null

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpFileObject.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/ftp/FtpFileObject.java
@@ -369,7 +369,7 @@ public class FtpFileObject extends AbstractFileObject<FtpFileSystem> {
         doGetChildren();
 
         // VFS-210
-        if (children.isEmpty()) {
+        if (children == null) {
             return null;
         } else if (children.isEmpty()) {
             return new String[0];


### PR DESCRIPTION
Fixes https://github.com/wso2/product-micro-integrator/issues/3364

