### PR TITLE
Add capability to configure Access mask for disk share

### DIFF
--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2ClientWrapper.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2ClientWrapper.java
@@ -42,7 +42,12 @@ import org.apache.commons.vfs2.provider.GenericFileName;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * A wrapper to the SMBClient for bundling the related client & connection instances.
@@ -60,6 +65,14 @@ public class Smb2ClientWrapper extends SMBClient {
     private Connection connection;
     private Session session;
     private DiskShare diskShare;
+    // Inline initialization of the Access Mask Map
+    private static final Map<String, Set<AccessMask>> ACCESS_MASK_MAP = new HashMap<String, Set<AccessMask>>() {{
+        put("READ", EnumSet.of(AccessMask.GENERIC_READ));
+        put("WRITE", EnumSet.of(AccessMask.GENERIC_WRITE));
+        put("READ_WRITE", EnumSet.of(AccessMask.GENERIC_READ, AccessMask.GENERIC_WRITE));
+        put("ALL", EnumSet.of(AccessMask.GENERIC_ALL));
+        put("MAXIMUM", EnumSet.of(AccessMask.MAXIMUM_ALLOWED));
+    }};
 
     protected Smb2ClientWrapper(final GenericFileName root, final FileSystemOptions fileSystemOptions)
             throws FileSystemException {
@@ -162,11 +175,35 @@ public class Smb2ClientWrapper extends SMBClient {
      * @return DiskEntry file
      */
     public DiskEntry getDiskEntryWrite(String path, boolean append) throws FileSystemException {
-        return diskShare.open(path, EnumSet.of(AccessMask.MAXIMUM_ALLOWED),
+        String diskShareAccessMask = Smb2FileSystemConfigBuilder.getInstance()
+                .getDiskShareAccessMask(fileSystemOptions);
+        Set<AccessMask> accessMask = getAccessMaskFromConfig(diskShareAccessMask);
+        return diskShare.open(path, accessMask,
                               EnumSet.of(FileAttributes.FILE_ATTRIBUTE_NORMAL),
                               EnumSet.of(SMB2ShareAccess.FILE_SHARE_WRITE),
                               append ? SMB2CreateDisposition.FILE_OPEN_IF : SMB2CreateDisposition.FILE_OVERWRITE_IF,
                               EnumSet.of(SMB2CreateOptions.FILE_NO_COMPRESSION));
+    }
+
+    /**
+     * Retrieves the set of \AccessMask\ values based on the provided configuration string.
+     *
+     * @param config the access mask configuration string
+     * @return a set of \AccessMask\ values corresponding to the configuration
+     * @throws IllegalArgumentException if the configuration string is null or invalid
+     */
+    public static Set<AccessMask> getAccessMaskFromConfig(String config) {
+        if (config == null) {
+            //To keep backward compatibility
+            return EnumSet.of(AccessMask.MAXIMUM_ALLOWED);
+        }
+        // Convert to uppercase for case-insensitive matching
+        Set<AccessMask> accessMask = ACCESS_MASK_MAP.get(config.toUpperCase());
+        if (accessMask == null) {
+            //To keep backward compatibility
+            return EnumSet.of(AccessMask.MAXIMUM_ALLOWED);
+        }
+        return accessMask;
     }
 
     /**

--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2FileObject.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2FileObject.java
@@ -151,7 +151,7 @@ public class Smb2FileObject extends AbstractFileObject<Smb2FileSystem> {
             }
         } catch (Exception e) {
             fileSystem.putClient(smb2ClientWrapper);
-            throw new FileSystemException("vfs.provider.smb2/diskentry-create.error", getName(), e.getCause());
+            throw new FileSystemException("vfs.provider.smb2/diskentry-create.error", getName(), e);
         }
         return new Smb2OutputStream(smb2ClientWrapper, os, diskEntryWrite);
     }
@@ -196,7 +196,7 @@ public class Smb2FileObject extends AbstractFileObject<Smb2FileSystem> {
             }
         } catch (Exception e) {
             fileSystem.putClient(smb2ClientWrapper);
-            throw new FileSystemException("vfs.provider.smb2/diskentry-create.error", getName(), e.getCause());
+            throw new FileSystemException("vfs.provider.smb2/diskentry-create.error", getName(), e);
         }
         return new Smb2InputStream(smb2ClientWrapper, is, this, diskEntry);
     }
@@ -240,7 +240,7 @@ public class Smb2FileObject extends AbstractFileObject<Smb2FileSystem> {
                     diskEntryFolderWrite.rename(fileObject.getRelPathToShare());
                     diskEntryFolderWrite.close();
                 } catch (Exception e) {
-                    throw new FileSystemException("vfs.provider.smb2/diskentry-create.error", getName(), e.getCause());
+                    throw new FileSystemException("vfs.provider.smb2/diskentry-create.error", getName(), e);
                 } finally {
                     fileSystem.putClient(smb2ClientWrapper);
                 }
@@ -261,7 +261,7 @@ public class Smb2FileObject extends AbstractFileObject<Smb2FileSystem> {
                         }
                     }
                 } catch (Exception e) {
-                    throw new FileSystemException("vfs.provider.smb2/diskentry-create.error", getName(), e.getCause());
+                    throw new FileSystemException("vfs.provider.smb2/diskentry-create.error", getName(), e);
                 }
             }
         }

--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2FileSystemConfigBuilder.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2FileSystemConfigBuilder.java
@@ -29,6 +29,7 @@ public class Smb2FileSystemConfigBuilder extends FileSystemConfigBuilder {
 
     private static final Smb2FileSystemConfigBuilder BUILDER = new Smb2FileSystemConfigBuilder();
     private static final String ENCRYPTION_ENABLED = "EncryptionEnabled";
+    public static final String DISK_SHARE_ACCESS_MASK = "diskShareAccessMask";
 
     public static Smb2FileSystemConfigBuilder getInstance() {
         return BUILDER;
@@ -46,6 +47,21 @@ public class Smb2FileSystemConfigBuilder extends FileSystemConfigBuilder {
     }
 
     /**
+     * Get the DiskShareAccessMask parameter for smb2 servers.
+     *
+     * @param opts The FileSystem options.
+     * @return The DiskShareAccessMask parameter.
+     */
+    public String getDiskShareAccessMask(FileSystemOptions opts) {
+        Object param = getParam(opts, DISK_SHARE_ACCESS_MASK);
+        if (param == null || !(param instanceof String)) {
+            return null; // Return null if param is null or not a String
+        }
+        String config = ((String) param).toUpperCase(); // Convert to uppercase
+        return config;
+    }
+
+    /**
      * Set the EncryptionEnabled parameter for SMB2 servers.
      *
      * @param opts            The FileSystem options.
@@ -53,6 +69,16 @@ public class Smb2FileSystemConfigBuilder extends FileSystemConfigBuilder {
      */
     public void setEncryptionEnabled(FileSystemOptions opts, boolean encryptionEnabled) {
         setParam(opts, ENCRYPTION_ENABLED, encryptionEnabled);
+    }
+
+    /**
+     * Set the DiskShareAccessMask parameter for SMB2 servers.
+     *
+     * @param opts The FileSystem options.
+     * @param mask The DiskShareAccessMask parameter.
+     */
+    public void setDiskShareAccessMask(FileSystemOptions opts, String mask) {
+        setParam(opts, DISK_SHARE_ACCESS_MASK, mask);
     }
 
     @Override


### PR DESCRIPTION


## Purpose
Add capability to configure diskShare access mask for each operation in file connector

Fixes: https://github.com/wso2/product-micro-integrator/issues/4047