### PR TITLE
Handle null password when creating AuthenticationContext

### DIFF
--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2ClientWrapper.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2ClientWrapper.java
@@ -127,8 +127,12 @@ public class Smb2ClientWrapper extends SMBClient {
             authDomain = null;
         }
 
-        //if username == "" the client tries to authenticate "anonymously". It's also possible to submit "guest" as username
-        AuthenticationContext authContext = new AuthenticationContext(userName, password.toCharArray(), authDomain);
+        //if username == "" the client tries to authenticate "anonymously". It's also possible to submit "guest" as
+        // username Password may be null depending on upstream auth handling. Avoid NullPointerException when
+        // converting to char[] by falling back to an empty array. This preserves constructor contract without
+        // altering authentication flow.
+        char[] pwd = (password != null) ? password.toCharArray() : new char[0];
+        AuthenticationContext authContext = new AuthenticationContext(userName, pwd, authDomain);
 
         //a connection stack is: SMBClient > Connection > Session > DiskShare
         try {


### PR DESCRIPTION
## Purpose

Password received from upstream authentication flow can be null in some scenarios. Converting directly to char[] caused a NullPointerException during context initialization.

This change safely falls back to an empty char array when password is null, preserving behavior and preventing runtime failures.

Fixes: https://github.com/wso2/product-micro-integrator/issues/4587



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where SMB2 authentication could fail with a crash when handling missing or null credentials, improving connection stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->