### PR TITLE
Add file name encoding support

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.vfs2.impl;
 
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.vfs2.CacheStrategy;
@@ -728,6 +732,17 @@ public class DefaultFileSystemManager implements FileSystemManager {
                 SftpFileSystemConfigBuilder builder = SftpFileSystemConfigBuilder.getInstance();
                 if (builder.getAvoidPermissionCheck(fileSystemOptions) == null) {
                     builder.setAvoidPermissionCheck(fileSystemOptions, permissionCheck);
+                }
+
+                String fileNameEncoding = queryParam.get(SftpConstants.FILE_NAME_ENCODING);
+                if (fileNameEncoding != null && !fileNameEncoding.isEmpty()) {
+                    try {
+                        Charset.forName(fileNameEncoding);
+                        builder.setFileNameEncoding(fileSystemOptions, fileNameEncoding);
+                    } catch (IllegalCharsetNameException | UnsupportedCharsetException e) {
+                        log.warn("Invalid filename encoding provided: " + fileNameEncoding
+                            + ". Falling back to UTF-8.");
+                    }
                 }
 
                 String timeoutStr = queryParam.get(SftpConstants.TIMEOUT);

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpClient.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpClient.java
@@ -23,6 +23,9 @@ import com.jcraft.jsch.ChannelSftp;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
 import com.jcraft.jsch.SftpException;
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.UnsupportedCharsetException;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.UserAuthenticationData;
@@ -66,6 +69,13 @@ public class SftpClient {
                     } catch (final SftpException e) {
                         throw new FileSystemException("vfs.provider.sftp/change-work-directory.error", workingDirectory, e);
                     }
+                }
+                String fileNameEncoding = SftpFileSystemConfigBuilder.getInstance()
+                    .getFileNameEncoding(fso);
+                if (fileNameEncoding != null && !fileNameEncoding.isEmpty()) {
+                    // safe to assume the encoding is supported as it is already
+                    // validated in SftpFileSystemConfigBuilder
+                    channel.setFilenameEncoding(Charset.forName(fileNameEncoding));
                 }
             } catch (JSchException | FileSystemException e) {
                 throw new FileSystemException("vfs.provider.sftp/change-work-directory.error", e);

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpConstants.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpConstants.java
@@ -58,4 +58,7 @@ public interface SftpConstants {
      * the public key (fingerprint) of the SSH/SFTP server.
      **/
     String STRICT_HOST_KEY_CHECKING = "transport.vfs.StrictHostKeyChecking";
+
+    /** Denote the file name encoding. */
+    String FILE_NAME_ENCODING = "fileNameEncoding";
 }


### PR DESCRIPTION
Add the functionality to specify the encoding of the file name 
Fixes wso2/product-micro-integrator/issues/4651

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a FILE_NAME_ENCODING parameter for SFTP to specify character encoding for file names.
  * Validates provided charset names and falls back to UTF-8 when invalid or unsupported.
  * Improves handling of international and non-ASCII file names across SFTP connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->