### PR TITLE
Fix SMB2 connector ignoring configured port (always connects on 445)

### DIFF
--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2ClientWrapper.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2ClientWrapper.java
@@ -136,7 +136,9 @@ public class Smb2ClientWrapper extends SMBClient {
 
         //a connection stack is: SMBClient > Connection > Session > DiskShare
         try {
-            connection = smbClient.connect(rootName.getHostName());
+            // GenericFileName#getPort() always returns a positive value: either the port explicitly
+            // configured in the URI, or the protocol's default port (445) when none was specified.
+            connection = smbClient.connect(rootName.getHostName(), rootName.getPort());
             session = connection.authenticate(authContext);
             String share = ((Smb2FileName) rootName).getShareName();
             diskShare = (DiskShare) session.connectShare(share);


### PR DESCRIPTION
## Problem

The WSO2 File Connector accepts a `<port>` parameter for SMB2 connections, and the connector-side code (`wso2-extensions/esb-connector-file`) correctly builds the VFS URI as `smb2://user:pass@host:port/share`. `Smb2FileNameParser` correctly parses that port into the resulting `FileName`.

However, `Smb2ClientWrapper#setupClient()` never uses it:

```java
connection = smbClient.connect(rootName.getHostName());
```

`smbj`'s `SMBClient` only has a single-arg `connect(String)` overload here being called, which always negotiates on the default SMB port (445). Any configured non-default port is silently discarded, so SMB2 servers listening on a non-standard port are unreachable.

Reported downstream as wso2/product-integrator-mi#4932, reproduced with a Samba server bound to a non-default host port.

## Fix

`GenericFileName#getPort()` always returns a positive value: either the explicitly configured port, or the protocol default (445) when none was specified. Use the `connect(String hostname, int port)` overload unconditionally with that value.

```java
connection = smbClient.connect(rootName.getHostName(), rootName.getPort());
```

## Testing

- `mvn -pl commons-vfs2-sandbox -am compile` builds cleanly.
- Verified `com.hierynomus.smbj.SMBClient` ships both `connect(String)` and `connect(String, int)` overloads in the bundled `smbj` jar.

Fixes wso2/product-integrator-mi#4932