### PR TITLE
Disable exec command check with transport.vfs.AvoidPermissionCheck

### DIFF
--- a/commons-vfs2/pom.xml
+++ b/commons-vfs2/pom.xml
@@ -73,7 +73,7 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>com.jcraft</groupId>
+      <groupId>com.github.mwiede</groupId>
       <artifactId>jsch</artifactId>
       <optional>true</optional>
     </dependency>

--- a/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
+++ b/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
@@ -260,17 +260,32 @@ public class SftpFileObject extends AbstractFileObject<SftpFileSystem> {
 
     @Override
     protected boolean doIsExecutable() throws Exception {
-        return getPermissions(true).isExecutable();
+        if (isPermissionCheckRequired()) {
+            return getPermissions(true).isExecutable();
+        }
+        return true;
     }
 
     @Override
     protected boolean doIsReadable() throws Exception {
-        return getPermissions(true).isReadable();
+        if (isPermissionCheckRequired()) {
+            return getPermissions(true).isReadable();
+        }
+        return true;
     }
 
     @Override
     protected boolean doIsWriteable() throws Exception {
-        return getPermissions(true).isWritable();
+        if (isPermissionCheckRequired()) {
+            return getPermissions(true).isWritable();
+        }
+        return true;
+    }
+
+    private boolean isPermissionCheckRequired() {
+        final String permissionCheck = SftpFileSystemConfigBuilder.getInstance()
+                .getAvoidPermissionCheck(getAbstractFileSystem().getFileSystemOptions());
+        return permissionCheck == null || !permissionCheck.equalsIgnoreCase("true");
     }
 
     /**

--- a/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpFileSystem.java
+++ b/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpFileSystem.java
@@ -100,7 +100,9 @@ public class SftpFileSystem extends AbstractFileSystem {
         super(rootName, null, fileSystemOptions);
         this.session = Objects.requireNonNull(session, "session");
         connectTimeout = SftpFileSystemConfigBuilder.getInstance().getConnectTimeout(fileSystemOptions);
-        if (SftpFileSystemConfigBuilder.getInstance().isDisableDetectExecChannel(fileSystemOptions)) {
+        final SftpFileSystemConfigBuilder configBuilder = SftpFileSystemConfigBuilder.getInstance();
+        if (configBuilder.isDisableDetectExecChannel(fileSystemOptions)
+                || "true".equalsIgnoreCase(configBuilder.getAvoidPermissionCheck(fileSystemOptions))) {
             execDisabled = true;
         } else {
             execDisabled = detectExecDisabled();

--- a/pom.xml
+++ b/pom.xml
@@ -427,9 +427,9 @@
         <version>${ant.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.jcraft</groupId>
+        <groupId>com.github.mwiede</groupId>
         <artifactId>jsch</artifactId>
-        <version>${jsch.version}</version>
+        <version>2.27.7</version>
       </dependency>
       <dependency>
         <groupId>jcifs</groupId>


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

This PR ports https://github.com/wso2/wso2-commons-vfs/pull/49 and use "isDisableDetectExecChannel" flag to disable execCheck, which might cause the connection to hang.

Resolves https://github.com/wso2/product-integrator-mi/issues/4946

This also upgrades jsch library to fix the build issue caused by https://github.com/wso2/wso2-commons-vfs/pull/160