### PR TITLE
Improve the resiliency of the sftp file protocol

### DIFF
--- a/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
+++ b/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
@@ -355,20 +355,13 @@ public class DefaultFileSystemManager implements FileSystemManager {
             return;
         }
 
-        // make sure all discovered components in
-        // org.apache.commons.vfs2.impl.StandardFileSystemManager.configure(Element)
-        // are closed here
-        for (final FileProvider provider : providers.values()) {
-            closeComponent(provider);
-        }
         // Close the file system providers.
         providers.values().forEach(this::closeComponent);
-        // unregister all
+
         // Close the other components
         closeComponent(vfsProvider);
         closeComponent(fileReplicator);
         closeComponent(tempFileStore);
-        closeComponent(filesCache);
         closeComponent(defaultProvider);
 
         // unregister all providers here, so if any components have local file references

--- a/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/local/GenericFileNameParser.java
+++ b/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/local/GenericFileNameParser.java
@@ -44,20 +44,15 @@ public class GenericFileNameParser extends LocalFileNameParser {
         // empty
     }
 
+    /*
+     * Here the rootFileName can only be "/" (see above) put this "/" is also in the
+     * path name so its of no value for the LocalFileName instance
+     */
     @Override
-    protected FileName createFileName(String scheme, String rootFile, String path, FileType fileType) {
-        return null;
+    protected FileName createFileName(final String scheme, final String rootFile, final String path,
+            final FileType type) {
+        return new LocalFileName(scheme, "", path, type);
     }
-
-//    /*
-//     * Here the rootFileName can only be "/" (see above) put this "/" is also in the
-//     * path name so its of no value for the LocalFileName instance
-//     */
-//    @Override
-//    protected FileName createFileName(final String scheme, final String rootFile, final String path,
-//            final FileType type) {
-//        return new LocalFileName(scheme, "", path, type);
-//    }
 
     /**
      * Extracts the root prefix from a URI string, which has had the scheme removed.

--- a/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpClientFactory.java
+++ b/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpClientFactory.java
@@ -214,7 +214,8 @@ public final class SftpClientFactory {
                 final int proxyPort = builder.getProxyPort(fileSystemOptions);
                 final SftpFileSystemConfigBuilder.ProxyType proxyType = builder.getProxyType(fileSystemOptions);
                 final String proxyUser = builder.getProxyUser(fileSystemOptions);
-                char[] proxyPassword = builder.getProxyPassword(fileSystemOptions).toCharArray();
+                String proxyPasswordStr = builder.getProxyPassword(fileSystemOptions);
+                char[] proxyPassword = proxyPasswordStr != null ? proxyPasswordStr.toCharArray() : null;
                 Proxy proxy = null;
                 UserAuthenticator proxyAuth = SftpFileSystemConfigBuilder.getInstance().getProxyUserAuthenticator
                         (fileSystemOptions);

--- a/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpClientFactory.java
+++ b/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpClientFactory.java
@@ -107,17 +107,21 @@ public final class SftpClientFactory {
         JSch.setLogger(new JSchLogger());
     }
 
-    private static void addIdentities(final JSch jsch, final File sshDir, final IdentityProvider[] identities)
-            throws FileSystemException {
+    private static void addIdentities(final JSch jsch, final File sshDir, final IdentityProvider[] identities,
+            final String passPhrase) throws FileSystemException {
         if (identities != null) {
             for (final IdentityProvider info : identities) {
-                addIdentity(jsch, info);
+                if (passPhrase != null && info instanceof IdentityInfo) {
+                    addIdentity(jsch, (IdentityInfo) info, passPhrase);
+                } else {
+                    addIdentity(jsch, info);
+                }
             }
         } else {
             // Load the private key (rsa-key only)
             final File privateKeyFile = new File(sshDir, "id_rsa");
             if (privateKeyFile.isFile() && privateKeyFile.canRead()) {
-                addIdentity(jsch, new IdentityInfo(privateKeyFile));
+                addIdentity(jsch, new IdentityInfo(privateKeyFile), passPhrase);
             }
         }
     }
@@ -162,7 +166,8 @@ public final class SftpClientFactory {
             jsch.setIdentityRepository(repositoryFactory.create(jsch));
         }
 
-        addIdentities(jsch, sshDir, identities);
+        final String passPhrase = builder.getIdentityPassPhrase(fileSystemOptions);
+        addIdentities(jsch, sshDir, identities, passPhrase);
         setConfigRepository(jsch, sshDir, configRepository, loadOpenSSHConfig);
 
         UserAuthenticationData proxyAuthData = null;
@@ -386,7 +391,7 @@ public final class SftpClientFactory {
     private SftpClientFactory() {
     }
 
-    private static void addIndentity(final JSch jsch, final IdentityInfo info, String passPhrase) throws
+    private static void addIdentity(final JSch jsch, final IdentityInfo info, String passPhrase) throws
             FileSystemException {
         try {
             final String privateKeyFile = info.getPrivateKey() != null ? info.getPrivateKey().getAbsolutePath() : null;

--- a/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
+++ b/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
@@ -197,6 +197,9 @@ public class SftpFileObject extends AbstractFileObject<SftpFileSystem> {
                     throw new FileNotFoundException(getName());
                 }
                 throw new FileSystemException(e);
+            } catch (final Exception e) {
+                putChannel(channel);
+                throw e;
             }
             return new SftpInputStream(channel, inputStream, bufferSize);
         }

--- a/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
+++ b/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
@@ -186,8 +186,6 @@ public class SftpFileObject extends AbstractFileObject<SftpFileSystem> {
                 // VFS-210: sftp allows to gather an input stream even from a directory and will
                 // fail on first read. So we need to check the type anyway
                 if (!getType().hasContent()) {
-                    // VFS-832: Sftp channel should put back when throw an exception
-                    putChannel(channel);
                     throw new FileSystemException("vfs.provider/read-not-file.error", getName());
                 }
                 inputStream = channel.get(relPath);

--- a/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
+++ b/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpFileObject.java
@@ -540,6 +540,7 @@ public class SftpFileObject extends AbstractFileObject<SftpFileSystem> {
                     // Try one retry — possibly transient channel issue
                     try {
                         channelSftp.disconnect();
+                        channelSftp = getAbstractFileSystem().getChannel();
                         setStat(channelSftp.stat(relPath));
                     } catch (SftpException retryEx) {
                         // TODO - not strictly true, but jsch 0.1.2 does not give us

--- a/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpFileSystem.java
+++ b/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpFileSystem.java
@@ -66,6 +66,8 @@ public class SftpFileSystem extends AbstractFileSystem {
 
     private volatile ChannelSftp idleChannel;
 
+    private volatile boolean isFileSystemClosed;
+
     private final Duration connectTimeout;
 
     /**
@@ -141,6 +143,7 @@ public class SftpFileSystem extends AbstractFileSystem {
 
     @Override
     protected void doCloseCommunicationLink() {
+        isFileSystemClosed = true;
         if (idleChannel != null) {
             synchronized (this) {
                 if (idleChannel != null) {
@@ -361,6 +364,10 @@ public class SftpFileSystem extends AbstractFileSystem {
      * @param channelSftp the SFTP channel.
      */
     protected void putChannel(final ChannelSftp channelSftp) {
+        if (isFileSystemClosed) {
+            channelSftp.disconnect();
+            return;
+        }
         if (idleChannel == null) {
             synchronized (this) {
                 if (idleChannel == null) {

--- a/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpFileSystem.java
+++ b/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpFileSystem.java
@@ -299,6 +299,7 @@ public class SftpFileSystem extends AbstractFileSystem {
                     doCloseCommunicationLink();
                     session = SftpFileProvider.createSession((GenericFileName) getRootName(),
                         getFileSystemOptions());
+                    isFileSystemClosed = false;
                 }
             }
         }

--- a/commons-vfs2/src/test/java/com/jcraft/jsch/TestIdentityRepositoryFactory.java
+++ b/commons-vfs2/src/test/java/com/jcraft/jsch/TestIdentityRepositoryFactory.java
@@ -27,6 +27,6 @@ import org.wso2.org.apache.commons.vfs2.provider.sftp.IdentityRepositoryFactory;
 public class TestIdentityRepositoryFactory implements IdentityRepositoryFactory {
     @Override
     public IdentityRepository create(final JSch jsch) {
-        return new LocalIdentityRepository(jsch);
+        return new LocalIdentityRepository(jsch.instLogger);
     }
 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

This PR adds the following improvements, which were identified by comparing vfs-commons 2.2.x and vfs-commons-2.10.x. Original PR which migrated fixes between branches : https://github.com/wso2/wso2-commons-vfs/pull/133

- [Fix SftpFileObject to re-establish channel connection after disconnect](https://github.com/wso2/wso2-commons-vfs/pull/163/commits/cdb2013354f6c996c7ae533cfd9ac5ca6fef8c54)
- [Refactor createFileName method in GenericFileNameParser](https://github.com/wso2/wso2-commons-vfs/pull/163/commits/a5e46add18ae90280795b4f241912572028f1ee3)
- [Handle null proxy password in SftpClientFactory](https://github.com/wso2/wso2-commons-vfs/pull/163/commits/9b45c42769b6d0b2fc3cfd0f00280071006d5691)
- [Remove redundant closeComponent for each provider in DefaultFileSystem](https://github.com/wso2/wso2-commons-vfs/pull/163/commits/f87b9ccd4d21fcb6f7c60bb95aed82ab4ad47397)
- [Enhance SFTP file handling to manage channel disconnection](https://github.com/wso2/wso2-commons-vfs/pull/163/commits/c7fea2e5824cbd15eca29993fb2b1be924c85362) 
- [Enhance SftpClientFactory to support passphrase for identity management](https://github.com/wso2/wso2-commons-vfs/pull/163/commits/d5c0ecfae64ad73ce4b0d5f7bde22a0442a5fd72)