### PR TITLE
Add configurable SMB2 disk share access mask via URI query parameter

### DIFF
--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2ClientWrapper.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2ClientWrapper.java
@@ -186,7 +186,7 @@ public class Smb2ClientWrapper extends SMBClient {
     public DiskEntry getDiskEntryWrite(String path, boolean append) throws FileSystemException {
         ArrayList<String> diskShareAccessMask = Smb2FileSystemConfigBuilder.getInstance()
                 .getDiskShareAccessMask(fileSystemOptions);
-        Set<AccessMask> accessMask = getAccessMaskFromConfig(diskShareAccessMask);
+        Set<AccessMask> accessMask = resolveAccessMaskOrDefault(diskShareAccessMask, AccessMask.MAXIMUM_ALLOWED);
         return diskShare.open(path, accessMask,
                               EnumSet.of(FileAttributes.FILE_ATTRIBUTE_NORMAL),
                               EnumSet.of(SMB2ShareAccess.FILE_SHARE_WRITE),
@@ -198,13 +198,15 @@ public class Smb2ClientWrapper extends SMBClient {
      * Retrieves the set of \AccessMask\ values based on the provided configuration string.
      *
      * @param config the access mask configuration string
+     * @param defaultMask the default \AccessMask\ value to use if the configuration string is null or empty
      * @return a set of \AccessMask\ values corresponding to the configuration
      * @throws IllegalArgumentException if the configuration string is null or invalid
      */
-    public static Set<AccessMask> getAccessMaskFromConfig(ArrayList<String> config) {
+    private static Set<AccessMask> resolveAccessMaskOrDefault(ArrayList<String> config, AccessMask defaultMask) {
         if (config == null || config.isEmpty()) {
             // To keep backward compatibility
-            return EnumSet.of(AccessMask.MAXIMUM_ALLOWED);
+            LOG.debug("Disk share access mask is not configured. Using default access mask: " + defaultMask);
+            return EnumSet.of(defaultMask);
         }
 
         Set<AccessMask> accessMasks = EnumSet.noneOf(AccessMask.class);
@@ -224,7 +226,7 @@ public class Smb2ClientWrapper extends SMBClient {
 
         if (accessMasks.isEmpty()) {
             // To keep backward compatibility
-            return EnumSet.of(AccessMask.MAXIMUM_ALLOWED);
+            return EnumSet.of(defaultMask);
         }
 
         return accessMasks;
@@ -250,8 +252,11 @@ public class Smb2ClientWrapper extends SMBClient {
      */
     public DiskEntry getDiskEntryFolderWrite(String path) {
 
+        ArrayList<String> diskShareAccessMask = Smb2FileSystemConfigBuilder.getInstance()
+                .getDiskShareAccessMask(fileSystemOptions);
+        Set<AccessMask> accessMask = resolveAccessMaskOrDefault(diskShareAccessMask, AccessMask.GENERIC_ALL);
         return diskShare.openDirectory(path,
-                EnumSet.of(AccessMask.GENERIC_ALL),
+                accessMask,
                 EnumSet.of(FileAttributes.FILE_ATTRIBUTE_NORMAL),
                 EnumSet.of(SMB2ShareAccess.FILE_SHARE_READ),
                 SMB2CreateDisposition.FILE_OPEN_IF,

--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2FileProvider.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2FileProvider.java
@@ -26,12 +26,15 @@ import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.UserAuthenticationData;
 import org.apache.commons.vfs2.provider.AbstractOriginatingFileProvider;
 import org.apache.commons.vfs2.provider.GenericFileName;
+import org.apache.commons.vfs2.provider.QueryParamConfigurer;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
-public class Smb2FileProvider extends AbstractOriginatingFileProvider {
+public class Smb2FileProvider extends AbstractOriginatingFileProvider implements QueryParamConfigurer {
 
     /**
      * Authenticator types.
@@ -43,6 +46,8 @@ public class Smb2FileProvider extends AbstractOriginatingFileProvider {
             Arrays.asList(Capability.CREATE, Capability.DELETE, Capability.RENAME, Capability.GET_TYPE,
                           Capability.LIST_CHILDREN, Capability.READ_CONTENT, Capability.GET_LAST_MODIFIED,
                           Capability.URI, Capability.WRITE_CONTENT, Capability.APPEND_CONTENT));
+
+    private static final String DISK_SHARE_ACCESS_MASK = "transport.vfs.diskShareAccessMask";
 
     public Smb2FileProvider() {
 
@@ -71,5 +76,14 @@ public class Smb2FileProvider extends AbstractOriginatingFileProvider {
             return getFileNameParser().parseUri(getContext(), base, uri);
         }
         throw new FileSystemException("vfs.provider/filename-parser-missing.error");
+    }
+
+    @Override
+    public void configure(FileSystemOptions fileSystemOptions, Map<String, String> queryParams) {
+
+        if (queryParams.containsKey(DISK_SHARE_ACCESS_MASK)) {
+            String[] masks = queryParams.get(DISK_SHARE_ACCESS_MASK).split(",");
+            Smb2FileSystemConfigBuilder.getInstance().setDiskShareAccessMask(fileSystemOptions, new ArrayList<>(Arrays.asList(masks)));
+        }
     }
 }

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
@@ -45,6 +45,7 @@ import org.apache.commons.vfs2.provider.DefaultURLStreamHandler;
 import org.apache.commons.vfs2.provider.FileProvider;
 import org.apache.commons.vfs2.provider.FileReplicator;
 import org.apache.commons.vfs2.provider.LocalFileProvider;
+import org.apache.commons.vfs2.provider.QueryParamConfigurer;
 import org.apache.commons.vfs2.provider.TemporaryFileStore;
 import org.apache.commons.vfs2.provider.UriParser;
 import org.apache.commons.vfs2.provider.VfsComponent;
@@ -806,6 +807,12 @@ public class DefaultFileSystemManager implements FileSystemManager {
                                         (proxyPassword != null) ? proxyPassword : ""));
                     }
                 }
+            }
+            if (provider instanceof QueryParamConfigurer) {
+                if (fileSystemOptions == null) {
+                    fileSystemOptions = new FileSystemOptions();
+                }
+                ((QueryParamConfigurer) provider).configure(fileSystemOptions, queryParam);
             }
             if (provider != null) {
                 return provider.findFile(realBaseFile, uri, fileSystemOptions);

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/QueryParamConfigurer.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/QueryParamConfigurer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.commons.vfs2.provider;
+
+import org.apache.commons.vfs2.FileSystemOptions;
+
+import java.util.Map;
+
+/**
+ * Optional interface for {@link FileProvider} implementations that wish to configure
+ * {@link FileSystemOptions} from URI query parameters.
+ *
+ * <p>When a provider registered with {@link org.apache.commons.vfs2.impl.DefaultFileSystemManager}
+ * implements this interface, the manager will call {@link #configure} before resolving the file,
+ * passing the parsed query parameters from the URI. Providers that do not implement this interface
+ * are unaffected.
+ */
+public interface QueryParamConfigurer {
+
+    /**
+     * Configures the given {@link FileSystemOptions} using the supplied URI query parameters.
+     *
+     * @param fileSystemOptions the options to populate
+     * @param queryParams       the parsed query parameters from the URI
+     */
+    void configure(FileSystemOptions fileSystemOptions, Map<String, String> queryParams);
+}


### PR DESCRIPTION
## Purpose

Add configurable SMB2 disk share access mask via URI query parameter

Introduces QueryParamConfigurer interface in core so providers can populate FileSystemOptions from URI query params without reflection. Smb2FileProvider implements it to read diskShareAccessMask (`transport.vfs.diskShareAccessMask`) and store it via the new Smb2FileSystemConfigBuilder; Smb2ClientWrapper resolves the mask at runtime with a safe fallback to the previous default.

Fixes: https://github.com/wso2/product-integrator-mi/issues/4950