### PR TITLE
Add option to configure JSch connect timeout and keep alive count

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
@@ -756,6 +756,26 @@ public class DefaultFileSystemManager implements FileSystemManager {
                     builder.setTimeout(fileSystemOptions, timeout);
                 }
 
+                String connectTimeoutStr = queryParam.get(SftpConstants.CONNECT_TIMEOUT);
+                if (connectTimeoutStr != null && builder.getConnectTimeout(fileSystemOptions) == null) {
+                    try {
+                        int connectTimeout = Integer.parseInt(connectTimeoutStr);
+                        builder.setConnectTimeout(fileSystemOptions, connectTimeout);
+                    } catch (NumberFormatException e) {
+                        log.warn("Invalid connect timeout " + connectTimeoutStr + " specified in FileURI.");
+                    }
+                }
+
+                String keepAliveCountStr = queryParam.get(SftpConstants.KEEP_ALIVE_COUNT);
+                if (keepAliveCountStr != null && builder.getKeepAliveCountMax(fileSystemOptions) == null) {
+                    try {
+                        int keepAliveCount = Integer.parseInt(keepAliveCountStr);
+                        builder.setKeepAliveCountMax(fileSystemOptions, keepAliveCount);
+                    } catch (NumberFormatException e) {
+                        log.warn("Invalid keep alive count " + keepAliveCountStr + " specified in FileURI.");
+                    }
+                }
+
                 if ("true".equals(queryParam.get(SftpConstants.SFTP_PATH_FROM_ROOT))) {
                     ((SftpFileSystemConfigBuilder) (((SftpFileProvider) provider).getConfigBuilder()))
                             .setUserDirIsRoot(fileSystemOptions, false);

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpClientFactory.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpClientFactory.java
@@ -94,6 +94,11 @@ public final class SftpClientFactory {
                 session.setPassword(new String(password));
             }
 
+            final Integer keepAliveCountMax = builder.getKeepAliveCountMax(fileSystemOptions);
+            if (keepAliveCountMax != null) {
+                session.setServerAliveCountMax(keepAliveCountMax);
+            }
+
             final Integer timeout = builder.getTimeout(fileSystemOptions);
             if (timeout != null) {
                 session.setTimeout(timeout.intValue());
@@ -159,7 +164,12 @@ public final class SftpClientFactory {
                 session.setConfig(config);
             }
             session.setDaemonThread(true);
-            session.connect();
+            final Integer connectTimeout = builder.getConnectTimeout(fileSystemOptions);
+            if (connectTimeout != null) {
+                session.connect(connectTimeout);
+            } else {
+                session.connect();
+            }
         } catch (final Exception exc) {
             throw new FileSystemException("vfs.provider.sftp/connect.error", exc, hostname);
         } finally {

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpConstants.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpConstants.java
@@ -47,6 +47,16 @@ public interface SftpConstants {
     /** Default Timeout for the connection. */
     String TIMEOUT = "timeout";
 
+    /**
+     * Connection timeout for the connection.
+     */
+    String CONNECT_TIMEOUT = "connectTimeout";
+
+    /**
+     * Keep alive count for the connection.
+     */
+    String KEEP_ALIVE_COUNT = "keepAliveCount";
+
     /** Number of retries allow to connect to server */
     String RETRY_COUNT = "retryCount";
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileSystemConfigBuilder.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpFileSystemConfigBuilder.java
@@ -118,6 +118,8 @@ public final class SftpFileSystemConfigBuilder extends FileSystemConfigBuilder {
 
     private static final String STRICT_HOST_KEY_CHECKING = _PREFIX + ".STRICT_HOST_KEY_CHECKING";
     private static final String TIMEOUT = _PREFIX + ".TIMEOUT";
+    private static final String CONNECT_TIMEOUT = _PREFIX + ".CONNECT_TIMEOUT";
+    private static final String KEEP_ALIVE_COUNT_MAX = _PREFIX + ".KEEP_ALIVE_COUNT_MAX";
     private static final String USER_DIR_IS_ROOT = _PREFIX + ".USER_DIR_IS_ROOT";
     private static final String ENCODING = _PREFIX + ".ENCODING";
     private static final String PASS_PHRASE = "identitypassphrase";
@@ -636,5 +638,45 @@ public final class SftpFileSystemConfigBuilder extends FileSystemConfigBuilder {
      */
     public void setUserInfo(final FileSystemOptions opts, final UserInfo info) {
         this.setParam(opts, UserInfo.class.getName(), info);
+    }
+
+    /**
+     * Sets the connect timeout value on Jsch session.
+     *
+     * @param opts The FileSystem options.
+     * @param connectTimeout The connect timeout in milliseconds.
+     */
+    public void setConnectTimeout(final FileSystemOptions opts, final Integer connectTimeout) {
+        this.setParam(opts, CONNECT_TIMEOUT, connectTimeout);
+    }
+
+    /**
+     * Gets the connect timeout value on Jsch session.
+     *
+     * @param fileSystemOptions The FileSystem options.
+     * @return The connect timeout in milliseconds.
+     */
+    public Integer getConnectTimeout(FileSystemOptions fileSystemOptions) {
+        return this.getInteger(fileSystemOptions, CONNECT_TIMEOUT);
+    }
+
+    /**
+     * Sets the maximum number of keep alive messages to send on Jsch session.
+     *
+     * @param opts The FileSystem options.
+     * @param keepAliveCountMax The maximum number of keep alive messages to send.
+     */
+    public void setKeepAliveCountMax(final FileSystemOptions opts, final Integer keepAliveCountMax) {
+        this.setParam(opts, KEEP_ALIVE_COUNT_MAX, keepAliveCountMax);
+    }
+
+    /**
+     * Gets the maximum number of keep alive messages to send on Jsch session.
+     *
+     * @param fileSystemOptions The FileSystem options.
+     * @return The maximum number of keep alive messages to send.
+     */
+    public Integer getKeepAliveCountMax(FileSystemOptions fileSystemOptions) {
+        return this.getInteger(fileSystemOptions, KEEP_ALIVE_COUNT_MAX);
     }
 }


### PR DESCRIPTION
## Purpose

Add option to configure JSch session timeouts.
This PR will add support to set connect timeout and keep alive count.

**Note**
JSch internally uses the same value for both the keep-alive interval and the socket timeout. Since we already have the Timeout parameter, which sets the socket timeout (and is also used by JSch as the keep-alive interval), introducing a separate Keep-alive interval parameter could lead to ambiguity.

Fixes:  https://github.com/wso2/product-integrator-mi/issues/4951