### PR TITLE
[2.10.x] Add option to configure JSch connect timeout and keep alive count

### DIFF
--- a/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
+++ b/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
@@ -18,6 +18,7 @@ package org.wso2.org.apache.commons.vfs2.impl;
 
 import java.io.File;
 import java.lang.reflect.Constructor;
+import java.time.Duration;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -836,6 +837,26 @@ public class DefaultFileSystemManager implements FileSystemManager {
                         log.warn("Invalid timeout " + timeoutStr + " specified in FileURI.");
                     }
                     builder.setTimeout(fileSystemOptions, timeout);
+                }
+
+                String connectTimeoutStr = queryParam.get(SftpConstants.CONNECT_TIMEOUT);
+                if (connectTimeoutStr != null && Duration.ZERO.equals(builder.getConnectTimeout(fileSystemOptions))) {
+                    try {
+                        int connectTimeout = Integer.parseInt(connectTimeoutStr);
+                        builder.setConnectTimeout(fileSystemOptions, Duration.ofMillis(connectTimeout));
+                    } catch (NumberFormatException e) {
+                        log.warn("Invalid connect timeout " + connectTimeoutStr + " specified in FileURI.");
+                    }
+                }
+
+                String keepAliveCountStr = queryParam.get(SftpConstants.KEEP_ALIVE_COUNT);
+                if (keepAliveCountStr != null && builder.getKeepAliveCountMax(fileSystemOptions) == null) {
+                    try {
+                        int keepAliveCount = Integer.parseInt(keepAliveCountStr);
+                        builder.setKeepAliveCountMax(fileSystemOptions, keepAliveCount);
+                    } catch (NumberFormatException e) {
+                        log.warn("Invalid keep alive count " + keepAliveCountStr + " specified in FileURI.");
+                    }
                 }
 
                 if ("true".equals(queryParam.get(SftpConstants.SFTP_PATH_FROM_ROOT))) {

--- a/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpClientFactory.java
+++ b/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpClientFactory.java
@@ -179,6 +179,11 @@ public final class SftpClientFactory {
                 session.setPassword(new String(password));
             }
 
+            final Integer keepAliveCountMax = builder.getKeepAliveCountMax(fileSystemOptions);
+            if (keepAliveCountMax != null) {
+                session.setServerAliveCountMax(keepAliveCountMax);
+            }
+
             final Duration sessionTimeout = builder.getSessionTimeout(fileSystemOptions);
             if (sessionTimeout != null) {
                 session.setTimeout(DurationUtils.toMillisInt(sessionTimeout));
@@ -252,7 +257,12 @@ public final class SftpClientFactory {
                 session.setConfig(config);
             }
             session.setDaemonThread(true);
-            session.connect();
+            final Duration connectTimeout = builder.getConnectTimeout(fileSystemOptions);
+            if (connectTimeout != null) {
+                session.connect(DurationUtils.toMillisInt(connectTimeout));
+            } else {
+                session.connect();
+            }
         } catch (final Exception exc) {
             throw new FileSystemException("vfs.provider.sftp/connect.error", exc, hostname);
         } finally {

--- a/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpConstants.java
+++ b/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpConstants.java
@@ -48,6 +48,16 @@ public interface SftpConstants {
     /** Default Timeout for the connection. */
     String TIMEOUT = "timeout";
 
+    /**
+     * Connection timeout for the connection.
+     */
+    String CONNECT_TIMEOUT = "connectTimeout";
+
+    /**
+     * Keep alive count for the connection.
+     */
+    String KEEP_ALIVE_COUNT = "keepAliveCount";
+
     /** Number of retries allow to connect to server */
     String RETRY_COUNT = "retryCount";
 

--- a/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpFileSystemConfigBuilder.java
+++ b/commons-vfs2/src/main/java/org/wso2/org/apache/commons/vfs2/provider/sftp/SftpFileSystemConfigBuilder.java
@@ -110,6 +110,7 @@ public final class SftpFileSystemConfigBuilder extends FileSystemConfigBuilder {
     private static final SftpFileSystemConfigBuilder BUILDER = new SftpFileSystemConfigBuilder();
     private static final String COMPRESSION = PREFIX + "COMPRESSION";
     private static final String CONNECT_TIMEOUT = PREFIX + ".CONNECT_TIMEOUT";
+    private static final String KEEP_ALIVE_COUNT_MAX = PREFIX + ".KEEP_ALIVE_COUNT_MAX";
     private static final String ENCODING = PREFIX + ".ENCODING";
     private static final String HOST_KEY_CHECK_ASK = "ask";
     private static final String HOST_KEY_CHECK_NO = "no";
@@ -882,6 +883,26 @@ public final class SftpFileSystemConfigBuilder extends FileSystemConfigBuilder {
      */
     public void setIdentityPassPhrase(FileSystemOptions opts, String identityPassPhrase) throws FileSystemException {
         setParam(opts, PASS_PHRASE, identityPassPhrase);
+    }
+
+    /**
+     * Sets the maximum number of keep-alive messages to send on the Jsch session.
+     *
+     * @param opts The FileSystem options.
+     * @param keepAliveCountMax The maximum number of keep-alive messages to send.
+     */
+    public void setKeepAliveCountMax(final FileSystemOptions opts, final Integer keepAliveCountMax) {
+        this.setParam(opts, KEEP_ALIVE_COUNT_MAX, keepAliveCountMax);
+    }
+
+    /**
+     * Gets the maximum number of keep-alive messages to send on the Jsch session.
+     *
+     * @param options The FileSystem options.
+     * @return The maximum number of keep-alive messages, or null if not set.
+     */
+    public Integer getKeepAliveCountMax(final FileSystemOptions options) {
+        return this.getInteger(options, KEEP_ALIVE_COUNT_MAX);
     }
 
 }


### PR DESCRIPTION
## Purpose

Add option to configure JSch session timeouts.
This PR will add support to set connect timeout and keep alive count.

**Note**
JSch internally uses the same value for both the keep-alive interval and the socket timeout. Since we already have the Timeout parameter, which sets the socket timeout (and is also used by JSch as the keep-alive interval), introducing a separate Keep-alive interval parameter could lead to ambiguity.

Fixes:  https://github.com/wso2/product-integrator-mi/issues/4951