### PR TITLE
Prevent stalled SFTP sessions from blocking VFS pollers and senders

### DIFF
--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/impl/DefaultFileSystemManager.java
@@ -746,34 +746,53 @@ public class DefaultFileSystemManager implements FileSystemManager {
                     }
                 }
 
-                String timeoutStr = queryParam.get(SftpConstants.TIMEOUT);
-                Integer timeout = null;
-                if (timeoutStr != null && builder.getTimeout(fileSystemOptions) == null) {
+                // Store only valid URI values. Invalid and negative values stay
+                // unset so the connection factory can choose a safe default.
+                String timeoutParameter = queryParam.get(SftpConstants.TIMEOUT);
+                if (timeoutParameter != null && builder.getTimeout(fileSystemOptions) == null) {
                     try {
-                        timeout = Integer.parseInt(timeoutStr);
+                        int timeoutMillis = Integer.parseInt(timeoutParameter);
+                        if (timeoutMillis >= 0) {
+                            builder.setTimeout(fileSystemOptions, timeoutMillis);
+                        } else {
+                            log.warn("The SFTP timeout value '" + timeoutParameter
+                                    + "' in the file URI is negative. The default value will be used.");
+                        }
                     } catch (NumberFormatException e) {
-                        log.warn("Invalid timeout " + timeoutStr + " specified in FileURI.");
-                    }
-                    builder.setTimeout(fileSystemOptions, timeout);
-                }
-
-                String connectTimeoutStr = queryParam.get(SftpConstants.CONNECT_TIMEOUT);
-                if (connectTimeoutStr != null && builder.getConnectTimeout(fileSystemOptions) == null) {
-                    try {
-                        int connectTimeout = Integer.parseInt(connectTimeoutStr);
-                        builder.setConnectTimeout(fileSystemOptions, connectTimeout);
-                    } catch (NumberFormatException e) {
-                        log.warn("Invalid connect timeout " + connectTimeoutStr + " specified in FileURI.");
+                        log.warn("The SFTP timeout value '" + timeoutParameter
+                                + "' in the file URI is invalid. The default value will be used.");
                     }
                 }
 
-                String keepAliveCountStr = queryParam.get(SftpConstants.KEEP_ALIVE_COUNT);
-                if (keepAliveCountStr != null && builder.getKeepAliveCountMax(fileSystemOptions) == null) {
+                String connectTimeoutParameter = queryParam.get(SftpConstants.CONNECT_TIMEOUT);
+                if (connectTimeoutParameter != null && builder.getConnectTimeout(fileSystemOptions) == null) {
                     try {
-                        int keepAliveCount = Integer.parseInt(keepAliveCountStr);
-                        builder.setKeepAliveCountMax(fileSystemOptions, keepAliveCount);
+                        int connectTimeoutMillis = Integer.parseInt(connectTimeoutParameter);
+                        if (connectTimeoutMillis >= 0) {
+                            builder.setConnectTimeout(fileSystemOptions, connectTimeoutMillis);
+                        } else {
+                            log.warn("The SFTP connection timeout value '" + connectTimeoutParameter
+                                    + "' in the file URI is negative. The default value will be used.");
+                        }
                     } catch (NumberFormatException e) {
-                        log.warn("Invalid keep alive count " + keepAliveCountStr + " specified in FileURI.");
+                        log.warn("The SFTP connection timeout value '" + connectTimeoutParameter
+                                + "' in the file URI is invalid. The default value will be used.");
+                    }
+                }
+
+                String keepAliveCountParameter = queryParam.get(SftpConstants.KEEP_ALIVE_COUNT);
+                if (keepAliveCountParameter != null && builder.getKeepAliveCountMax(fileSystemOptions) == null) {
+                    try {
+                        int keepAliveCount = Integer.parseInt(keepAliveCountParameter);
+                        if (keepAliveCount >= 0) {
+                            builder.setKeepAliveCountMax(fileSystemOptions, keepAliveCount);
+                        } else {
+                            log.warn("The SFTP keep alive count value '" + keepAliveCountParameter
+                                    + "' in the file URI is negative. The default value will be used.");
+                        }
+                    } catch (NumberFormatException e) {
+                        log.warn("The SFTP keep alive count value '" + keepAliveCountParameter
+                                + "' in the file URI is invalid. The default value will be used.");
                     }
                 }
 

--- a/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpClientFactory.java
+++ b/commons-vfs2/src/main/java/org/apache/commons/vfs2/provider/sftp/SftpClientFactory.java
@@ -35,6 +35,9 @@ import org.apache.commons.vfs2.util.UserAuthenticatorUtils;
 
 import java.io.File;
 import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Create a JSch Session instance.
@@ -49,6 +52,53 @@ public final class SftpClientFactory {
     }
 
     private SftpClientFactory() {
+    }
+
+    // These defaults keep SFTP connections bounded when an endpoint omits the
+    // related settings. The values stay local and do not change the supplied
+    // file system options.
+    private static final String TIMEOUT_DEFAULT_PROPERTY = "vfs.sftp.timeout.default";
+    private static final String KEEP_ALIVE_COUNT_DEFAULT_PROPERTY = "vfs.sftp.keepAliveCount.default";
+    private static final String CONNECT_TIMEOUT_DEFAULT_PROPERTY = "vfs.sftp.connectTimeout.default";
+    private static final int DEFAULT_TIMEOUT_MILLIS = 30000;
+    private static final int DEFAULT_KEEP_ALIVE_COUNT = 3;
+    private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 30000;
+    private static final int JSCH_DEFAULT_KEEP_ALIVE_COUNT = 1;
+
+    /** Records whether the socket timeout warning has already been logged. */
+    private static final AtomicBoolean BARE_TIMEOUT_WARNING_LOGGED = new AtomicBoolean();
+    /** Records invalid property values that have already been reported. */
+    private static final Set<String> INVALID_PROPERTY_WARNINGS = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Reads a nonnegative integer from a system property. Missing or invalid
+     * values return null so the caller can choose the correct fallback. Zero
+     * remains a valid value that disables the related limit.
+     */
+    private static Integer readSftpProperty(final String propertyName) {
+        final String propertyValue = System.getProperty(propertyName);
+        if (propertyValue == null) {
+            return null;
+        }
+        try {
+            final int parsedValue = Integer.parseInt(propertyValue.trim());
+            if (parsedValue < 0) {
+                warnAboutInvalidPropertyOnce(propertyName, propertyValue, "is negative");
+                return null;
+            }
+            return parsedValue;
+        } catch (final NumberFormatException e) {
+            warnAboutInvalidPropertyOnce(propertyName, propertyValue, "is not a number");
+            return null;
+        }
+    }
+
+    private static void warnAboutInvalidPropertyOnce(final String propertyName, final String propertyValue,
+                                                     final String reason) {
+        if (INVALID_PROPERTY_WARNINGS.add(propertyName + "=" + propertyValue)) {
+            LOG.warn(propertyName + "='" + propertyValue + "' " + reason
+                    + "; ignoring it and continuing normal fallback resolution");
+        }
     }
 
     /**
@@ -94,14 +144,64 @@ public final class SftpClientFactory {
                 session.setPassword(new String(password));
             }
 
-            final Integer keepAliveCountMax = builder.getKeepAliveCountMax(fileSystemOptions);
-            if (keepAliveCountMax != null) {
-                session.setServerAliveCountMax(keepAliveCountMax);
+            // An endpoint value has the highest priority. A valid system
+            // property is next. Remaining values use the compatible default.
+            final Integer endpointKeepAliveCount = builder.getKeepAliveCountMax(fileSystemOptions);
+            final Integer endpointTimeoutMillis = builder.getTimeout(fileSystemOptions);
+            final Integer endpointConnectTimeoutMillis = builder.getConnectTimeout(fileSystemOptions);
+            final Integer propertyKeepAliveCount = endpointKeepAliveCount == null
+                    ? readSftpProperty(KEEP_ALIVE_COUNT_DEFAULT_PROPERTY) : null;
+            final Integer propertyTimeoutMillis = endpointTimeoutMillis == null
+                    ? readSftpProperty(TIMEOUT_DEFAULT_PROPERTY) : null;
+
+            final int effectiveTimeoutMillis;
+            final String timeoutSource;
+            if (endpointTimeoutMillis != null) {
+                effectiveTimeoutMillis = endpointTimeoutMillis;
+                timeoutSource = "endpoint";
+                session.setTimeout(endpointTimeoutMillis.intValue());
+            } else if (propertyTimeoutMillis != null) {
+                effectiveTimeoutMillis = propertyTimeoutMillis;
+                timeoutSource = "system property";
+                if (effectiveTimeoutMillis > 0) {
+                    session.setTimeout(effectiveTimeoutMillis);
+                }
+            } else {
+                effectiveTimeoutMillis = DEFAULT_TIMEOUT_MILLIS;
+                timeoutSource = "default";
+                session.setTimeout(effectiveTimeoutMillis);
             }
 
-            final Integer timeout = builder.getTimeout(fileSystemOptions);
-            if (timeout != null) {
-                session.setTimeout(timeout.intValue());
+            // Keep the JSch default when the endpoint sets only a timeout.
+            final int effectiveKeepAliveCount;
+            final String keepAliveCountSource;
+            if (endpointKeepAliveCount != null) {
+                effectiveKeepAliveCount = endpointKeepAliveCount;
+                keepAliveCountSource = "endpoint";
+                session.setServerAliveCountMax(endpointKeepAliveCount);
+            } else if (propertyKeepAliveCount != null) {
+                effectiveKeepAliveCount = propertyKeepAliveCount;
+                keepAliveCountSource = "system property";
+                session.setServerAliveCountMax(propertyKeepAliveCount);
+            } else if (endpointTimeoutMillis != null) {
+                effectiveKeepAliveCount = JSCH_DEFAULT_KEEP_ALIVE_COUNT;
+                keepAliveCountSource = "JSch default";
+            } else {
+                effectiveKeepAliveCount = DEFAULT_KEEP_ALIVE_COUNT;
+                keepAliveCountSource = "default";
+                session.setServerAliveCountMax(effectiveKeepAliveCount);
+            }
+
+            // Warn once when keep alive checks do not support an active timeout.
+            if (effectiveTimeoutMillis > 0 && effectiveKeepAliveCount == 0) {
+                final String warningMessage = "SFTP timeout " + effectiveTimeoutMillis
+                        + " is active while keep alive count is zero. Slow but responsive operations may be "
+                        + "disconnected.";
+                if (BARE_TIMEOUT_WARNING_LOGGED.compareAndSet(false, true)) {
+                    LOG.warn(warningMessage);
+                } else if (LOG.isDebugEnabled()) {
+                    LOG.debug(warningMessage);
+                }
             }
 
             final UserInfo userInfo = builder.getUserInfo(fileSystemOptions);
@@ -164,12 +264,32 @@ public final class SftpClientFactory {
                 session.setConfig(config);
             }
             session.setDaemonThread(true);
-            final Integer connectTimeout = builder.getConnectTimeout(fileSystemOptions);
-            if (connectTimeout != null) {
-                session.connect(connectTimeout);
+            // Pass the resolved connection timeout directly. This preserves an
+            // explicit zero and keeps existing timeout only endpoints unchanged.
+            final Integer propertyConnectTimeoutMillis = endpointConnectTimeoutMillis == null
+                    ? readSftpProperty(CONNECT_TIMEOUT_DEFAULT_PROPERTY) : null;
+            final int effectiveConnectTimeoutMillis;
+            final String connectTimeoutSource;
+            if (endpointConnectTimeoutMillis != null) {
+                effectiveConnectTimeoutMillis = endpointConnectTimeoutMillis;
+                connectTimeoutSource = "endpoint";
+            } else if (propertyConnectTimeoutMillis != null) {
+                effectiveConnectTimeoutMillis = propertyConnectTimeoutMillis;
+                connectTimeoutSource = "system property";
+            } else if (endpointTimeoutMillis != null) {
+                effectiveConnectTimeoutMillis = endpointTimeoutMillis;
+                connectTimeoutSource = "endpoint timeout";
             } else {
-                session.connect();
+                effectiveConnectTimeoutMillis = DEFAULT_CONNECT_TIMEOUT_MILLIS;
+                connectTimeoutSource = "default";
             }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("SFTP effective settings: timeout=" + effectiveTimeoutMillis + " from " + timeoutSource
+                        + ", keep alive count=" + effectiveKeepAliveCount + " from " + keepAliveCountSource
+                        + ", connection timeout=" + effectiveConnectTimeoutMillis + " from "
+                        + connectTimeoutSource);
+            }
+            session.connect(effectiveConnectTimeoutMillis);
         } catch (final Exception exc) {
             throw new FileSystemException("vfs.provider.sftp/connect.error", exc, hostname);
         } finally {


### PR DESCRIPTION


## Summary

This PR implements the Commons VFS part of the coordinated fix. It
bounds stalled SFTP sessions by resolving effective timeout and keep
alive settings when a session is created.


## Changes

### SFTP setting resolution

URI timeout values are accepted only when they are valid nonnegative
integers. Invalid values are reported and are not stored.

Unset settings are resolved in the SFTP client factory without
modifying `FileSystemOptions`. This preserves the existing connection
cache identity.

The effective precedence is:

1. An existing value in `FileSystemOptions`
2. A valid URI value when that option is unset
3. A valid system property for the same option
4. Existing timeout only compatibility behavior where applicable
5. The baked fallback when the option is still unset

For a timeout only endpoint, the existing JSch keep alive count of one
is retained and the connection timeout is derived from the endpoint
timeout, unless the corresponding option or system property is set.

The fallback values are a 30000 millisecond socket timeout, a keep
alive count of three, and a 30000 millisecond connection timeout.
Explicit zero values remain supported. Existing programmatic option
values are not rewritten.

Invalid property warnings are bounded by property name and value. The
effective values and their sources are available at debug level.

### Healthy unused connections

This change does not close a healthy connection merely because it is
unused. After the socket timeout expires, JSch sends a keep alive
request. A responsive server resets the cycle and the session remains
connected.

On this timeout path, the session is closed only after the configured
number of keep alive requests receive no response. Independent socket,
protocol, authentication, and server failures continue to follow their
normal error paths.


## Coordinated delivery

This PR should be delivered with the companion Synapse PR because
neither change independently completes the full fix.

Fixes: https://github.com/wso2/product-integrator-mi/issues/4954
