### PR TITLE
Honour the configured port for SMB2 connections

### DIFF
--- a/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2ClientWrapper.java
+++ b/commons-vfs2-sandbox/src/main/java/org/apache/commons/vfs2/provider/smb2/Smb2ClientWrapper.java
@@ -136,7 +136,12 @@ public class Smb2ClientWrapper extends SMBClient {
 
         //a connection stack is: SMBClient > Connection > Session > DiskShare
         try {
-            connection = smbClient.connect(rootName.getHostName());
+            //the port parsed from the smb2:// URI is stored on the file name; when it differs from the
+            //SMB2 default it has to be passed explicitly, since connect(host) always uses the default port
+            int port = rootName.getPort();
+            connection = (port > 0 && port != rootName.getDefaultPort())
+                    ? smbClient.connect(rootName.getHostName(), port)
+                    : smbClient.connect(rootName.getHostName());
             session = connection.authenticate(authContext);
             String share = ((Smb2FileName) rootName).getShareName();
             diskShare = (DiskShare) session.connectShare(share);


### PR DESCRIPTION
## Problem

`smb2://` URIs that specify a non-default port always connect on the default SMB2 port **445**. Any Samba server listening elsewhere is unreachable, failing with `Connection refused` against the closed default port:

```
org.apache.commons.vfs2.FileSystemException: Could not establish connection to "localhost".
    at org.apache.commons.vfs2.provider.smb2.Smb2ClientWrapper.setupClient(Smb2ClientWrapper.java:131)
Caused by: java.net.ConnectException: Connection refused (Connection refused)
    at com.hierynomus.smbj.SMBClient.connect(SMBClient.java:71)
```

This affects downstream consumers such as the WSO2 File Connector, which exposes a `<port>` parameter for SMB2 connections that has no effect.

## Root cause

`Smb2FileNameParser.parseUri()` correctly parses the port and stores it on `Smb2FileName`. But the connect call site in `Smb2ClientWrapper.setupClient()` never reads it:

```java
connection = smbClient.connect(rootName.getHostName());
```

This is the single-argument `SMBClient.connect(String)` overload, which hard-codes port 445 internally. SMBJ's `SMBClient.connect(String hostname, int port)` overload was simply never called, so the parsed port was dropped between the file name and the socket.

## Fix

Read the port from the file name and pass it to the two-argument overload when it differs from the default port that `Smb2FileNameParser` supplies:

```java
int port = rootName.getPort();
connection = (port > 0 && port != rootName.getDefaultPort())
        ? smbClient.connect(rootName.getHostName(), port)
        : smbClient.connect(rootName.getHostName());
```

Comparing against `rootName.getDefaultPort()` reuses the default already wired up by `Smb2FileNameParser` rather than restating `445` at the call site.

## Backwards compatibility

Default-port URIs are unaffected. `GenericFileName` substitutes the default port when a URI omits one, so a URI with no port — or an explicit `:445` — still takes the original single-argument `connect(host)` path, leaving that behaviour byte-for-byte unchanged. Only URIs carrying a genuinely non-default port take the new branch, and those are currently broken outright.

## Reproduction

Samba on a non-default port, with 445 closed on the host:

```yaml
services:
  samba:
    image: dockurr/samba
    environment:
      NAME: "Data"
      USER: "samba"
      PASS: "secret"
    ports:
      - 44501:445    # 445 NOT bound on the host
```

```java
StandardFileSystemManager manager = new StandardFileSystemManager();
manager.init();
manager.resolveFile("smb2://samba:secret@localhost:44501/Data/test.xml",
                    new FileSystemOptions());
```

**Before**

```
DEBUG ProxySocketFactory - Connecting to localhost/127.0.0.1:445   <-- wrong port
Caused by: java.net.ConnectException: Connection refused
```

**After**

```
DEBUG ProxySocketFactory - Connecting to localhost/127.0.0.1:44501  <-- configured port
  at com.hierynomus.smbj.connection.SMBProtocolNegotiator.negotiateDialect(...)
  (TCP connect succeeds, SMB2 negotiation begins)
```

Verified on a non-default port and re-checked that default-port and explicit-`:445` URIs still route through `connect(host)`.

Related public issue: wso2/product-integrator-mi#4932