### PR TITLE
Close the SMB2 disk entry when the output stream close fails

### DIFF
--- a/commons-vfs2-sandbox/src/main/java/org/wso2/org/apache/commons/vfs2/provider/smb2/Smb2FileObject.java
+++ b/commons-vfs2-sandbox/src/main/java/org/wso2/org/apache/commons/vfs2/provider/smb2/Smb2FileObject.java
@@ -393,13 +393,30 @@ public class Smb2FileObject extends AbstractFileObject<Smb2FileSystem> {
          */
         @Override
         protected void onClose() throws IOException {
+            IOException firstException = null;
             try {
                 if (out != null) {
                     out.close();
                 }
+            } catch (IOException e) {
+                firstException = e;
+            } catch (RuntimeException e) {
+                // smbj surfaces write/flush timeouts (and other transport failures) as an
+                // unchecked SMBRuntimeException. It must not skip diskEntry.close() below,
+                // otherwise the remote SMB2 file handle is leaked until the JVM/session ends.
+                firstException = new IOException(e);
+            }
+            try {
                 diskEntry.close();
+            } catch (RuntimeException e) {
+                if (firstException == null) {
+                    firstException = new IOException(e);
+                }
             } finally {
                 getAbstractFileSystem().putClient(client);
+            }
+            if (firstException != null) {
+                throw firstException;
             }
         }
     }


### PR DESCRIPTION
smbj reports write and flush timeouts as an unchecked SMBRuntimeException. That exception left onClose before the disk entry was closed, so the remote SMB2 file handle stayed open until the session ended.

Record the first failure, close the disk entry, return the client, and then report that failure to the caller. A failed write is still surfaced, and no handle is left behind.

Fixes: https://github.com/wso2/product-integrator-mi/issues/4981